### PR TITLE
added left-panel responsive fix

### DIFF
--- a/src/pages/Calculator/Steps/MixRatios.js
+++ b/src/pages/Calculator/Steps/MixRatios.js
@@ -532,7 +532,7 @@ const MixRatio = () => {
     <Grid xs={12} container>
       {renderSeedsSelected()}
       <Grid
-        xs={speciesSelection.seedsSelected.length > 0 ? 12 : 12}
+        xs={12}
         md={speciesSelection.seedsSelected.length > 0 ? 11 : 12}
         item
         justifyContent="center"

--- a/src/pages/Calculator/Steps/MixRatios.js
+++ b/src/pages/Calculator/Steps/MixRatios.js
@@ -25,7 +25,7 @@ const MixRatio = () => {
   const matchesXs = useMediaQuery(theme.breakpoints.down("xs"));
   const matchesSm = useMediaQuery(theme.breakpoints.down("sm"));
   const matchesMd = useMediaQuery(theme.breakpoints.down("md"));
-
+  const matchesUpMd = useMediaQuery(theme.breakpoints.up("md"));
   // useSelector for crops & mixRaxio reducer
 
   const dispatch = useDispatch();
@@ -146,37 +146,35 @@ const MixRatio = () => {
   };
   const renderSeedsSelected = () => {
     return (
-      <Grid item xs={3} md={1}>
-        <Box
-          sx={{
-            width: "100%",
-            height: "100%",
-            padding: 1,
-            backgroundColor: "#E5E7D5",
-            border: "#C7C7C7 solid 1px",
-          }}
-        >
-          {speciesSelection.seedsSelected.map((s, idx) => {
-            return (
-              <Fragment>
-                <img
-                  className={
-                    matchesXs
-                      ? "left-panel-img-xs"
-                      : matchesSm
-                      ? "left-panel-img-sm"
-                      : matchesMd
-                      ? "left-panel-img-md"
-                      : "left-panel-img"
-                  }
-                  src={s.thumbnail.src}
-                  alt={s.label}
-                  loading="lazy"
-                />
-                <Typography className="left-panel-text">{s.label}</Typography>
-              </Fragment>
-            );
-          })}
+      <Grid item xs={matchesMd ? 12 : 1}>
+        <Box className="selected-seeds-box">
+          <Grid
+            className="selected-seeds-container"
+            container
+            flexDirection={matchesMd ? "row" : "column"}
+          >
+            {speciesSelection.seedsSelected.map((s, idx) => {
+              return (
+                <Grid item className="selected-seeds-item">
+                  <img
+                    className={
+                      matchesXs
+                        ? "left-panel-img-xs"
+                        : matchesSm
+                        ? "left-panel-img-sm"
+                        : matchesMd
+                        ? "left-panel-img-md"
+                        : "left-panel-img"
+                    }
+                    src={s.thumbnail.src}
+                    alt={s.label}
+                    loading="lazy"
+                  />
+                  <Typography className="left-panel-text">{s.label}</Typography>
+                </Grid>
+              );
+            })}{" "}
+          </Grid>
         </Box>
       </Grid>
     );
@@ -534,7 +532,7 @@ const MixRatio = () => {
     <Grid xs={12} container>
       {renderSeedsSelected()}
       <Grid
-        xs={speciesSelection.seedsSelected.length > 0 ? 9 : 12}
+        xs={speciesSelection.seedsSelected.length > 0 ? 12 : 12}
         md={speciesSelection.seedsSelected.length > 0 ? 11 : 12}
         item
         justifyContent="center"

--- a/src/pages/Calculator/Steps/SpeciesSelection.js
+++ b/src/pages/Calculator/Steps/SpeciesSelection.js
@@ -223,37 +223,35 @@ const SpeciesSelection = () => {
   };
   const renderSeedsSelected = () => {
     return (
-      <Grid item xs={3} md={1}>
-        <Box
-          sx={{
-            width: "100%",
-            height: "100%",
-            padding: 1,
-            backgroundColor: "#E5E7D5",
-            border: "#C7C7C7 solid 1px",
-          }}
-        >
-          {seedsSelected.map((s, idx) => {
-            return (
-              <Fragment>
-                <img
-                  className={
-                    matchesXs
-                      ? "left-panel-img-xs"
-                      : matchesSm
-                      ? "left-panel-img-sm"
-                      : matchesMd
-                      ? "left-panel-img-md"
-                      : "left-panel-img"
-                  }
-                  src={s.thumbnail.src}
-                  alt={s.label}
-                  loading="lazy"
-                />
-                <Typography className="left-panel-text">{s.label}</Typography>
-              </Fragment>
-            );
-          })}
+      <Grid item xs={matchesMd ? 12 : 1}>
+        <Box className="selected-seeds-box">
+          <Grid
+            className="selected-seeds-container"
+            container
+            flexDirection={matchesMd ? "row" : "column"}
+          >
+            {speciesSelection.seedsSelected.map((s, idx) => {
+              return (
+                <Grid item className="selected-seeds-item">
+                  <img
+                    className={
+                      matchesXs
+                        ? "left-panel-img-xs"
+                        : matchesSm
+                        ? "left-panel-img-sm"
+                        : matchesMd
+                        ? "left-panel-img-md"
+                        : "left-panel-img"
+                    }
+                    src={s.thumbnail.src}
+                    alt={s.label}
+                    loading="lazy"
+                  />
+                  <Typography className="left-panel-text">{s.label}</Typography>
+                </Grid>
+              );
+            })}{" "}
+          </Grid>
         </Box>
       </Grid>
     );
@@ -311,7 +309,7 @@ const SpeciesSelection = () => {
     <Grid xs={12} container>
       {seedsSelected.length > 0 && renderSeedsSelected()}
       <Grid
-        xs={seedsSelected.length > 0 ? 9 : 12}
+        xs={seedsSelected.length > 0 ? 12 : 12}
         md={seedsSelected.length > 0 ? 11 : 12}
         item
         justifyContent="center"

--- a/src/pages/Calculator/Steps/SpeciesSelection.js
+++ b/src/pages/Calculator/Steps/SpeciesSelection.js
@@ -309,7 +309,7 @@ const SpeciesSelection = () => {
     <Grid xs={12} container>
       {seedsSelected.length > 0 && renderSeedsSelected()}
       <Grid
-        xs={seedsSelected.length > 0 ? 12 : 12}
+        xs={12}
         md={seedsSelected.length > 0 ? 11 : 12}
         item
         justifyContent="center"

--- a/src/pages/Calculator/Steps/steps.css
+++ b/src/pages/Calculator/Steps/steps.css
@@ -10,6 +10,20 @@ site-condition-header {
     margin-top: 25px;
     margin-bottom: 30px;
 }
+.selected-seeds-box {
+    width: 100%;
+    height: 100%;
+    padding: 1px;
+    background-color:#E5E7D5 ;
+    border: #C7C7C7 solid 1px;
+}
+.selected-seeds-container {
+    flex-wrap: nowrap !important;
+    overflow-x: scroll !important;
+}
+.selected-seeds-item {
+    padding: 0px 15px;
+}
 .panel-img {
     border-radius: 25px;
     width: 100%;


### PR DESCRIPTION
Left panel, when in mobile view, clutters the page with content. Solution to this is moving it to the top as a scrollable horizontal panel (only when page is in responsive view)


Expected results:
<img width="1504" alt="Screen Shot 2022-11-29 at 3 13 14 PM" src="https://user-images.githubusercontent.com/23531153/204669175-2dba0294-9066-447c-a443-4fefa7bb69c0.png">

<img width="516" alt="Screen Shot 2022-11-29 at 3 12 59 PM" src="https://user-images.githubusercontent.com/23531153/204669172-4c1371b0-d1f5-4cd0-9559-52f9f20cd78d.png">

<img width="539" alt="Screen Shot 2022-11-29 at 3 12 45 PM" src="https://user-images.githubusercontent.com/23531153/204669154-d90a85af-9b4a-4cf8-9078-986407884df9.png">
