### PR TITLE
review page

### DIFF
--- a/src/features/stepSlice.js
+++ b/src/features/stepSlice.js
@@ -1,5 +1,6 @@
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import dayjs from "dayjs";
+
 const initialState = {
   loading: false,
   error: false,

--- a/src/pages/Calculator/Steps/MixRatios.js
+++ b/src/pages/Calculator/Steps/MixRatios.js
@@ -10,7 +10,7 @@ import { Square } from "@mui/icons-material";
 import AccordionSummary from "@mui/material/AccordionSummary";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import {
-  calculateAllSteps,
+  calculateAllValues,
   calculateSeeds,
 } from "../../../shared/utils/calculate";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
@@ -66,29 +66,21 @@ const MixRatio = () => {
   };
   const handleUpdateAllSteps = (prevData, index) => {
     let data = [...prevData];
-    data[index] = calculateAllSteps(data[index]);
+    data[index] = calculateAllValues(data[index]);
     handleUpdateSteps("seedsSelected", data);
   };
-  const updateSeed = (val, key1, key2, seed) => {
+  const updateSeed = (val, key, seed) => {
     // find index of seed, parse a copy, update proper values, & send to Redux
     const index = speciesSelection.seedsSelected.findIndex(
       (s) => s.id === seed.id
     );
     let data = JSON.parse(JSON.stringify(speciesSelection.seedsSelected));
-    if (key2 === "") {
-      data[index][key1] = val;
-      handleUpdateSteps("seedsSelected", data);
-    } else {
-      // update deep values (ex: data[0].step1.percentOfSingleSpeciesRate)
-      // after single value is updated properly, we calculate & update all the other values.
-      data[index][key1][key2] = val;
-      const calculateVal = calculateSeeds(key1, data[index]);
-      data[index][calculateVal["key"]] = calculateVal["val"];
-      handleUpdateSteps("seedsSelected", data);
-      let newData = [...data];
-      newData[index] = calculateAllSteps(data[index]);
-      handleUpdateAllSteps(newData, index);
-    }
+    data[index][key] = val;
+    handleUpdateSteps("seedsSelected", data);
+    // create new copy of recently updated Redux state, calculate & update all seed's step data.
+    let newData = [...data];
+    newData[index] = calculateAllValues(data[index]);
+    handleUpdateAllSteps(newData, index);
   };
   const renderCustomizedLabel = ({
     cx,
@@ -212,7 +204,7 @@ const MixRatio = () => {
             }}
           >
             <Typography>
-              {Math.floor(data.step1.singleSpeciesSeedingRatePLS)}
+              {Math.floor(data.singleSpeciesSeedingRatePLS)}
             </Typography>
           </Box>
           <Typography>Lbs / Acre</Typography>
@@ -232,7 +224,7 @@ const MixRatio = () => {
           >
             <Typography>{Math.floor(data.mixSeedingRate)}</Typography>
           </Box>
-          <Typography>Lbs / Acre</Typography>
+          <Typography className="font-15">Lbs / Acre</Typography>
         </Grid>
         <Grid item xs={6}>
           <Box
@@ -275,7 +267,7 @@ const MixRatio = () => {
         <Grid item xs={12}>
           <Button
             onClick={(e) => {
-              updateSeed(!data.showSteps, "showSteps", "", data);
+              updateSeed(!data.showSteps, "showSteps", data);
             }}
             variant="outlined"
           >
@@ -288,7 +280,7 @@ const MixRatio = () => {
       </Grid>
     );
   };
-  const renderMixRatioFormLabel = (label1, label2, label3) => {
+  const renderFormLabel = (label1, label2, label3) => {
     return (
       <Grid container xs={12} className="mix-ratio-form-container">
         <Grid item xs={3}>
@@ -317,13 +309,16 @@ const MixRatio = () => {
       </Grid>
     );
   };
+  const renderFormInput = (data) => {
+    return <Grid xs={12} className="mix-ratio-form-container"></Grid>;
+  };
   const renderMixRateSteps = (data) => {
     return (
       <Grid container xs={12}>
         <Grid item xs={12}>
           <Typography className="mix-ratio-step-header">Step 1:</Typography>
         </Grid>
-        {renderMixRatioFormLabel(
+        {renderFormLabel(
           "Single Species Seeding Rate PLS",
           "% of Single Species Rate",
           "Mix Seeding Rate"
@@ -337,14 +332,9 @@ const MixRatio = () => {
               label="Single Species Seeding Rate PLS"
               variant="filled"
               handleChange={(e) => {
-                updateSeed(
-                  e.target.value,
-                  "step1",
-                  "singleSpeciesSeedingRatePLS",
-                  data
-                );
+                updateSeed(e.target.value, "singleSpeciesSeedingRatePLS", data);
               }}
-              value={data.step1.singleSpeciesSeedingRatePLS}
+              value={data.singleSpeciesSeedingRatePLS}
             />
             <Typography>Lbs / Acre</Typography>
           </Grid>
@@ -359,14 +349,9 @@ const MixRatio = () => {
               variant="filled"
               disabled={false}
               handleChange={(e) => {
-                updateSeed(
-                  e.target.value,
-                  "step1",
-                  "percentOfSingleSpeciesRate",
-                  data
-                );
+                updateSeed(e.target.value, "percentOfSingleSpeciesRate", data);
               }}
-              value={data.step1.percentOfSingleSpeciesRate}
+              value={data.percentOfSingleSpeciesRate}
             />
             <Typography>MCCC</Typography>
           </Grid>
@@ -389,7 +374,7 @@ const MixRatio = () => {
         <Grid item xs={12}>
           <Typography className="mix-ratio-step-header">Step 2: </Typography>
         </Grid>
-        {renderMixRatioFormLabel(
+        {renderFormLabel(
           "Single Species Seeding Rate PLS",
           "% of Single Species Rate",
           "Mix Seeding Rate"
@@ -402,9 +387,9 @@ const MixRatio = () => {
             label="Seeds / Pound"
             variant="filled"
             handleChange={(e) => {
-              updateSeed(e.target.value, "step2", "seedsPound", data);
+              updateSeed(e.target.value, "seedsPound", data);
             }}
-            value={data.step2.seedsPound}
+            value={data.seedsPound}
           />
         </Grid>
         <Grid item xs={1}>
@@ -437,7 +422,7 @@ const MixRatio = () => {
         <Grid item xs={12}>
           <Typography className="mix-ratio-step-header">Step 3: </Typography>
         </Grid>
-        {renderMixRatioFormLabel("Seeds/Acre", "% Survival", "Plants/Acre")}
+        {renderFormLabel("Seeds/Acre", "% Survival", "Plants/Acre")}
         <Grid item xs={3}>
           <NumberTextField
             className="text-field-100"
@@ -459,9 +444,9 @@ const MixRatio = () => {
             variant="filled"
             disabled={false}
             handleChange={(e) => {
-              updateSeed(e.target.value, "step3", "percentSurvival", data);
+              updateSeed(e.target.value, "percentSurvival", data);
             }}
-            value={data.step3.percentSurvival}
+            value={data.percentSurvival}
           />
         </Grid>
         <Grid item xs={1}>
@@ -480,7 +465,7 @@ const MixRatio = () => {
         <Grid item xs={12}>
           <Typography className="mix-ratio-step-header">Step 4: </Typography>
         </Grid>
-        {renderMixRatioFormLabel(
+        {renderFormLabel(
           "Plants/Acre",
           "Sq.Ft./Acre",
           "Aproximate Plants/Sq.Ft."
@@ -506,9 +491,9 @@ const MixRatio = () => {
             variant="filled"
             disabled={false}
             handleChange={(e) => {
-              updateSeed(e.target.value, "step4", "sqFtAcre", data);
+              updateSeed(e.target.value, "sqFtAcre", data);
             }}
-            value={data.step4.sqFtAcre}
+            value={data.sqFtAcre}
           />
         </Grid>
         <Grid item xs={1}>

--- a/src/pages/Calculator/Steps/ReviewMix.js
+++ b/src/pages/Calculator/Steps/ReviewMix.js
@@ -261,14 +261,15 @@ const ReviewMix = () => {
       <Grid container xs={12}>
         <Grid item xs={12}>
           <ResponsiveContainer width="100%" height={200}>
-            <ScatterChart width={400} height={400}>
+            <ScatterChart width={400} height={400} position="center">
               <CartesianGrid strokeDasharray="4" />
               <XAxis type="number" dataKey="x" name="stature" unit="acre" />
               <YAxis type="number" dataKey="y" name="weight" unit="lb" />
               <ZAxis dataKey="z" range={[1000, 1449]} name="score" unit="km" />
               <Tooltip cursor={{ strokeDasharray: "50 50" }} />
               <Scatter name="A school" data={data} fill="#E7885F">
-                <LabelList dataKey="x" />
+                {/* <LabelList dataKey="x" content={renderCustomizedScatterLabel} /> */}
+                <LabelList dataKey="x" fill="#fff" position="center" />
               </Scatter>
             </ScatterChart>
           </ResponsiveContainer>
@@ -276,6 +277,26 @@ const ReviewMix = () => {
       </Grid>
     );
   };
+  const renderCustomizedScatterLabel = (props) => {
+    const { x, y, width, height, value } = props;
+    const radius = 10;
+
+    return (
+      <g>
+        <circle cx={x + 20} cy={y + 25} r={radius} fill="#E7885F" />
+        <text
+          x={x + 20}
+          y={y + 25}
+          fill="#fff"
+          textAnchor="middle"
+          dominantBaseline="middle"
+        >
+          {value}
+        </text>
+      </g>
+    );
+  };
+
   const renderAccordian = (data) => {
     return (
       <Accordion xs={12} className="accordian-container">

--- a/src/pages/Calculator/Steps/ReviewMix.js
+++ b/src/pages/Calculator/Steps/ReviewMix.js
@@ -1,10 +1,812 @@
 import Grid from "@mui/material/Grid";
-import { Typography } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import { Typography, Box, Link, Button } from "@mui/material";
+import { useState, useEffect, Fragment } from "react";
+import { useSelector, useDispatch } from "react-redux";
+import {
+  PieChart,
+  Pie,
+  Sector,
+  Cell,
+  ResponsiveContainer,
+  ScatterChart,
+  Scatter,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  LabelList,
+  ZAxis,
+} from "recharts";
+
+import Accordion from "@mui/material/Accordion";
+import { Square } from "@mui/icons-material";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import {
+  calculateAllValues,
+  calculateSeeds,
+  calculateAllMixValues,
+} from "../../../shared/utils/calculate";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import { updateSteps } from "../../../features/stepSlice";
+import { NumberTextField } from "../../../components/NumberTextField";
+import { DSTSwitch } from "../../../components/Switch";
+
+import "./steps.css";
 
 const ReviewMix = () => {
+  // themes
+  const theme = useTheme();
+  const matchesXs = useMediaQuery(theme.breakpoints.down("xs"));
+  const matchesSm = useMediaQuery(theme.breakpoints.down("sm"));
+  const matchesMd = useMediaQuery(theme.breakpoints.down("md"));
+  const matchesUpMd = useMediaQuery(theme.breakpoints.up("md"));
+  // useSelector for crops & mixRaxio reducer
+
+  const dispatch = useDispatch();
+  const data = useSelector((state) => state.steps.value);
+  const speciesSelection = data.speciesSelection;
+  const plantsPerAcreSum = speciesSelection.seedsSelected.reduce(
+    (sum, a) => sum + a.plantsPerAcre,
+    0
+  );
+  const poundsOfSeedSum = speciesSelection.seedsSelected.reduce(
+    (sum, a) => sum + a.poundsOfSeed,
+    0
+  );
+  const poundsOfSeedArray = [];
+  const plantsPerAcreArray = [];
+  speciesSelection.seedsSelected.map((s, i) => {
+    plantsPerAcreArray.push({
+      name: s.label,
+      value: s.plantsPerAcre / plantsPerAcreSum,
+    });
+    poundsOfSeedArray.push({
+      name: s.label,
+      value: s.poundsOfSeed / poundsOfSeedSum,
+    });
+  });
+
+  const COLORS = ["#0088FE", "#00C49F", "#FFBB28", "#FF8042"];
+
+  const RADIAN = Math.PI / 180;
+
+  const handleUpdateSteps = (key, val) => {
+    const data = {
+      type: "speciesSelection",
+      key: key,
+      value: val,
+    };
+    dispatch(updateSteps(data));
+  };
+  const handleUpdateAllSteps = (prevData, index) => {
+    let data = [...prevData];
+    data[index] = calculateAllMixValues(data[index]);
+    handleUpdateSteps("seedsSelected", data);
+  };
+  const updateSeed = (val, key, seed) => {
+    // find index of seed, parse a copy, update proper values, & send to Redux
+    const index = speciesSelection.seedsSelected.findIndex(
+      (s) => s.id === seed.id
+    );
+    let data = JSON.parse(JSON.stringify(speciesSelection.seedsSelected));
+    data[index][key] = val;
+    handleUpdateSteps("seedsSelected", data);
+    let newData = [...data];
+    newData[index] = calculateAllMixValues(data[index]);
+    handleUpdateAllSteps(newData, index);
+  };
+  const renderCustomizedLabel = ({
+    cx,
+    cy,
+    midAngle,
+    innerRadius,
+    outerRadius,
+    percent,
+    index,
+  }) => {
+    const radius = innerRadius + (outerRadius - innerRadius) * 0.5;
+    const x = cx + radius * Math.cos(-midAngle * RADIAN);
+    const y = cy + radius * Math.sin(-midAngle * RADIAN);
+
+    return (
+      <text
+        x={x}
+        y={y}
+        fill="white"
+        textAnchor={x > cx ? "start" : "end"}
+        dominantBaseline="central"
+      >
+        {`${(percent * 100).toFixed(0)}%`}
+      </text>
+    );
+  };
+  const calculateSeedsSelectedSum = (key) => {
+    return data.speciesSelection.seedsSelected.reduce(
+      (sum, a) => sum + parseFloat(a[key]),
+      0
+    );
+  };
+  const renderStripedLabels = () => {
+    const labels = [
+      {
+        label: "Single Species Seeding Rate",
+        key: "singleSpeciesSeedingRatePLS",
+        val: calculateSeedsSelectedSum("singleSpeciesSeedingRatePLS"),
+      },
+      {
+        label: "Added to Mix",
+        key: "addedToMix",
+        val: calculateSeedsSelectedSum("addedToMix"),
+      },
+      {
+        label: "Drilled or Broadcast with Cultipack",
+        key: "drilled",
+        val: calculateSeedsSelectedSum("drilled"),
+      },
+      {
+        label: "Management Impacts on Mix (+57%)",
+        key: "managementImpactOnMix",
+        val: calculateSeedsSelectedSum("managementImpactOnMix"),
+      },
+      {
+        label: "Bulk Germination and Purity",
+        key: "bulkGerminationAndPurity",
+        val: calculateSeedsSelectedSum("bulkGerminationAndPurity"),
+      },
+    ];
+    const labels2 = [
+      { label: "Species Modifications" },
+      { label: "Species Review" },
+      { label: "Pounds for Purchase" },
+    ];
+    return (
+      <>
+        {labels.map((l, i) => {
+          return (
+            <Grid
+              container
+              sx={{ backgroundColor: !(i % 2) && "#e3e5d3" }}
+              xs={12}
+            >
+              <Grid item sx={{ textAlign: "justify" }} xs={10}>
+                {l.label}
+              </Grid>
+              <Grid item xs={2}>
+                {l.val}
+              </Grid>
+            </Grid>
+          );
+        })}
+      </>
+    );
+  };
+
+  const renderPieChart = (type) => {
+    const chartData =
+      type === "plantsPerAcre" ? plantsPerAcreArray : poundsOfSeedArray;
+
+    return (
+      <ResponsiveContainer width="100%" height={200}>
+        <PieChart width={400} height={400}>
+          <Pie
+            data={chartData}
+            cx="50%"
+            cy="50%"
+            labelLine={false}
+            label={renderCustomizedLabel}
+            outerRadius={80}
+            fill="#8884d8"
+            dataKey="value"
+          >
+            {chartData.map((entry, index) => (
+              <Cell
+                key={`cell-${index}`}
+                fill={COLORS[index % COLORS.length]}
+              />
+            ))}
+          </Pie>
+        </PieChart>
+      </ResponsiveContainer>
+    );
+  };
+  const renderSeedsSelected = () => {
+    return (
+      <Grid item xs={matchesMd ? 12 : 1}>
+        <Box className="selected-seeds-box">
+          <Grid
+            className="selected-seeds-container"
+            container
+            flexDirection={matchesMd ? "row" : "column"}
+          >
+            {speciesSelection.seedsSelected.map((s, idx) => {
+              return (
+                <Grid item className="selected-seeds-item">
+                  <img
+                    className={
+                      matchesXs
+                        ? "left-panel-img-xs"
+                        : matchesSm
+                        ? "left-panel-img-sm"
+                        : matchesMd
+                        ? "left-panel-img-md"
+                        : "left-panel-img"
+                    }
+                    src={s.thumbnail.src}
+                    alt={s.label}
+                    loading="lazy"
+                  />
+                  <Typography className="left-panel-text">{s.label}</Typography>
+                </Grid>
+              );
+            })}{" "}
+          </Grid>
+        </Box>
+      </Grid>
+    );
+  };
+  const renderAccordianChart = (obj) => {
+    const data = [
+      { x: 100, y: 700, z: 600 },
+      { x: 120, y: 100, z: 260 },
+      { x: 170, y: 300, z: 400 },
+      { x: 140, y: 250, z: 280 },
+      { x: 150, y: 400, z: 500 },
+      { x: 110, y: 280, z: 200 },
+    ];
+
+    return (
+      <Grid container xs={12}>
+        <Grid item xs={12}>
+          <ResponsiveContainer width="100%" height={200}>
+            <ScatterChart width={400} height={400}>
+              <CartesianGrid strokeDasharray="4" />
+              <XAxis type="number" dataKey="x" name="stature" unit="acre" />
+              <YAxis type="number" dataKey="y" name="weight" unit="lb" />
+              <ZAxis dataKey="z" range={[1000, 1449]} name="score" unit="km" />
+              <Tooltip cursor={{ strokeDasharray: "50 50" }} />
+              <Scatter name="A school" data={data} fill="#8884d8">
+                <LabelList dataKey="x" />
+              </Scatter>
+            </ScatterChart>
+          </ResponsiveContainer>
+        </Grid>
+      </Grid>
+    );
+  };
+  const renderAccordian = (data) => {
+    return (
+      <Accordion xs={12} className="accordian-container">
+        <AccordionSummary
+          className="accordian-header"
+          xs={12}
+          expandIcon={<ExpandMoreIcon />}
+          aria-controls="panel1a-content"
+          id="panel1a-header"
+        >
+          <Typography>{data.label}</Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          {renderAccordianChart(data)}
+          {renderAccordianDetail(data)}
+        </AccordionDetails>
+      </Accordion>
+    );
+  };
+  const renderAccordianDetail = (data) => {
+    return (
+      <Grid container xs={12}>
+        <Grid item xs={6}>
+          <Typography>Default Single Species Seeding Rate PLS</Typography>
+          <Box
+            sx={{
+              width: "50px",
+              height: "50px",
+              padding: "11px",
+              margin: "0 auto",
+              backgroundColor: "#E5E7D5",
+              border: "#C7C7C7 solid 1px",
+              borderRadius: "50%",
+            }}
+          >
+            <Typography>
+              {Math.floor(data.singleSpeciesSeedingRatePLS)}
+            </Typography>
+          </Box>
+          <Typography>Lbs / Acre</Typography>
+        </Grid>
+        <Grid item xs={6}>
+          <Typography>Default Mix Seeding Rate PLS</Typography>
+          <Box
+            sx={{
+              width: "50px",
+              height: "50px",
+              padding: "11px",
+              margin: "0 auto",
+              backgroundColor: "#E5E7D5",
+              border: "#C7C7C7 solid 1px",
+              borderRadius: "50%",
+            }}
+          >
+            <Typography>{Math.floor(data.mixSeedingRate)}</Typography>
+          </Box>
+          <Typography>Lbs / Acre</Typography>
+        </Grid>
+        <Grid item xs={6}>
+          <Box
+            sx={{
+              width: "110px",
+              height: "50px",
+              padding: "11px",
+              margin: "0 auto",
+              backgroundColor: "#E5E7D5",
+              border: "#C7C7C7 solid 1px",
+              borderRadius: "16px",
+            }}
+          >
+            <Typography>{Math.floor(data.plantsPerAcre)}</Typography>
+          </Box>
+          <Typography>Aprox plants per</Typography>
+          <Button variant="outlined">Sqft</Button>
+          {"   "}
+          <Button variant="contained">Acres</Button>
+        </Grid>
+        <Grid item xs={6}>
+          <Box
+            sx={{
+              width: "110px",
+              height: "50px",
+              padding: "11px",
+              margin: "0 auto",
+              backgroundColor: "#E5E7D5",
+              border: "#C7C7C7 solid 1px",
+              borderRadius: "16px",
+            }}
+          >
+            <Typography>{Math.floor(data.seedsPerAcre)}</Typography>
+          </Box>
+          <Typography>Seeds per</Typography>
+          <Button variant="contained">Sqft</Button>
+          {"   "}
+          <Button variant="outlined">Acres</Button>
+        </Grid>
+        {renderStripedLabels()}
+        <Grid item xs={12}>
+          <Button
+            onClick={(e) => {
+              updateSeed(!data.showSteps, "showSteps", data);
+            }}
+            variant="outlined"
+          >
+            {data.showSteps ? "Close Steps" : "Change My Rate"}
+          </Button>
+        </Grid>
+        <Grid item xs={12}>
+          {data.showSteps && renderMixRateSteps(data)}
+        </Grid>
+      </Grid>
+    );
+  };
+  const renderStepsForm = (label1, label2, label3) => {
+    if (Array.isArray(label2)) {
+      return (
+        <Grid container xs={12} className="mix-ratio-form-container">
+          <Grid item xs={3}>
+            <Typography
+              className={matchesMd ? "mix-ratio-form-label" : "no-display"}
+            >
+              {label1}
+            </Typography>
+          </Grid>
+          <Grid item xs={1}></Grid>
+          <Grid item xs={3}>
+            <Typography
+              className={matchesMd ? "mix-ratio-form-label" : "no-display"}
+            >
+              {label2[0]}
+            </Typography>
+          </Grid>
+          <Grid item xs={1}></Grid>
+          <Grid item xs={3}>
+            <Typography
+              className={matchesMd ? "mix-ratio-form-label" : "no-display"}
+            >
+              {label2[1]}
+            </Typography>
+          </Grid>
+          <Grid container xs={12} className="mix-ratio-form-container">
+            <Grid item xs={3}>
+              {label3}
+            </Grid>
+          </Grid>
+        </Grid>
+      );
+    } else {
+      return (
+        <Grid container xs={12} className="mix-ratio-form-container">
+          <Grid item xs={3}>
+            <Typography
+              className={matchesMd ? "mix-ratio-form-label" : "no-display"}
+            >
+              {label1}
+            </Typography>
+          </Grid>
+          <Grid item xs={1}></Grid>
+          <Grid item xs={3}>
+            <Typography
+              className={matchesMd ? "mix-ratio-form-label" : "no-display"}
+            >
+              {label2}
+            </Typography>
+          </Grid>
+          <Grid item xs={1}></Grid>
+          <Grid item xs={3}>
+            <Typography
+              className={matchesMd ? "mix-ratio-form-label" : "no-display"}
+            >
+              {label3}
+            </Typography>
+          </Grid>
+        </Grid>
+      );
+    }
+  };
+  const renderMixRateSteps = (data) => {
+    return (
+      <Grid container xs={12}>
+        <Grid item xs={12}>
+          <Typography className="mix-ratio-step-header">Step 1:</Typography>
+        </Grid>
+        {renderStepsForm(
+          "Single Species Seeding Rate PLS",
+          "% of Single Species Rate",
+          "Mix Seeding Rate"
+        )}
+        <Grid container xs={12} className="mix-ratio-form-container">
+          <Grid item xs={3}>
+            <NumberTextField
+              className="text-field-100"
+              id="filled-basic"
+              disabled={true}
+              label="Single Species Seeding Rate PLS"
+              variant="filled"
+              handleChange={(e) => {
+                updateSeed(e.target.value, "singleSpeciesSeedingRatePLS", data);
+              }}
+              value={data.seedsPerAcre}
+            />
+            <Typography className="font-15">Lbs / Acre</Typography>
+          </Grid>
+          <Grid item xs={1}>
+            <Typography className="math-icon">X</Typography>
+          </Grid>
+          <Grid item xs={3}>
+            <NumberTextField
+              className="text-field-100"
+              id="filled-basic"
+              label="% of Single Species Rate"
+              variant="filled"
+              disabled={false}
+              handleChange={(e) => {
+                updateSeed(e.target.value, "percentOfSingleSpeciesRate", data);
+              }}
+              value={data.percentOfSingleSpeciesRate}
+            />
+            <Typography className="font-15">MCCC Recommendation</Typography>
+          </Grid>
+          <Grid item xs={1}>
+            <Typography className="math-icon">=</Typography>
+          </Grid>
+          <Grid item xs={3}>
+            <NumberTextField
+              className="text-field-100"
+              id="filled-basic"
+              label="Mix Seeding Rate"
+              disabled={true}
+              variant="filled"
+              value={data.mixSeedingRate}
+            />
+            <Typography className="font-15">Lbs / Acre</Typography>
+          </Grid>
+        </Grid>
+
+        <Grid item xs={12}>
+          <Typography className="mix-ratio-step-header">Step 2: </Typography>
+        </Grid>
+        {renderStepsForm(
+          "Mix Seeding Rate PLS",
+          "Planting Method",
+          "Mix Seeding Rate PLS"
+        )}
+        <Grid item xs={3}>
+          <NumberTextField
+            className="text-field-100"
+            id="filled-basic"
+            disabled={false}
+            label="Mix Seeding Rate PLS"
+            variant="filled"
+            handleChange={(e) => {
+              updateSeed(e.target.value, "step2MixSeedingRatePLS", data);
+            }}
+            value={data.step2MixSeedingRatePLS}
+          />
+          <Typography className="font-15">Lbs / Acre</Typography>
+        </Grid>
+        <Grid item xs={1}>
+          <Typography className="math-icon">X</Typography>
+        </Grid>
+        <Grid item xs={3}>
+          <NumberTextField
+            className="text-field-100"
+            id="filled-basic"
+            disabled={true}
+            label="Planting Method"
+            variant="filled"
+            value={data.plantingMethod}
+          />
+        </Grid>
+        <Grid item xs={1}>
+          <Typography className="math-icon">=</Typography>
+        </Grid>
+        <Grid item xs={3}>
+          <NumberTextField
+            className="text-field-100"
+            id="filled-basic"
+            label="Mix Seeding Rate PLS"
+            variant="filled"
+            disabled={true}
+            value={data.step2Result}
+          />
+          <Typography className="font-15">Lbs / Acre</Typography>
+        </Grid>
+        <Grid item xs={12}>
+          <Typography className="mix-ratio-step-header">Step 3: </Typography>
+        </Grid>
+        {renderStepsForm(
+          "Mix Seeding Rate PLS",
+          "Mix Seeding Rate PLS",
+          "Management impact on mix"
+        )}
+        <Grid item xs={3}>
+          <NumberTextField
+            className="text-field-100"
+            id="filled-basic"
+            label="Mix Seeding Rate PLS"
+            variant="filled"
+            disabled={true}
+            value={data.step2Result}
+          />
+        </Grid>
+        <Grid item xs={1}>
+          <Typography className="math-icon">+</Typography>
+        </Grid>
+        <Grid item xs={1}>
+          <Typography className="math-icon">(</Typography>
+        </Grid>
+        <Grid item xs={2}>
+          <NumberTextField
+            className="text-field-100"
+            id="filled-basic"
+            label="Mix Seeding Rate PLS"
+            variant="filled"
+            disabled={false}
+            handleChange={(e) => {
+              updateSeed(e.target.value, "step3MixSeedingRatePLS", data);
+            }}
+            value={data.step3MixSeedingRatePLS}
+          />
+        </Grid>
+        <Grid item xs={1}>
+          <Typography className="math-icon">X</Typography>
+        </Grid>
+        <Grid item xs={2}>
+          <NumberTextField
+            className="text-field-100"
+            id="filled-basic"
+            label="Management Impact on Mix"
+            variant="filled"
+            disabled={true}
+            value={data.managementImpactOnMix}
+          />
+        </Grid>
+        <Grid item xs={1}>
+          <Typography className="math-icon">)</Typography>
+        </Grid>
+        <Grid container className="steps-row-2" xs={12}>
+          <Grid item xs={4}>
+            <Typography className="math-icon">=</Typography>
+          </Grid>
+          <Grid item xs={8}>
+            <NumberTextField
+              className="text-field-100"
+              id="filled-basic"
+              label="Mix Seeding Rate PLS"
+              variant="filled"
+              disabled={true}
+              value={data.step3Result}
+            />
+          </Grid>
+        </Grid>
+        <Grid item xs={12}>
+          <Typography className="mix-ratio-step-header">Step 4: </Typography>
+        </Grid>
+        {renderStepsForm("Mix Seeding Rate PLS", "% Germination", "% Purity")}
+        <Grid item xs={3}>
+          <NumberTextField
+            className="text-field-100"
+            id="filled-basic"
+            label="Mix Seeding Rate PLS"
+            variant="filled"
+            disabled={true}
+            value={data.step3Result}
+          />
+          <Typography className="font-15">Lbs / Acre</Typography>
+        </Grid>
+
+        <Grid item xs={1}>
+          <Typography className="math-icon">÷</Typography>
+        </Grid>
+        <Grid item xs={3}>
+          <NumberTextField
+            className="text-field-100"
+            id="filled-basic"
+            label="% Germination"
+            variant="filled"
+            disabled={false}
+            handleChange={(e) => {
+              updateSeed(e.target.value, "germinationPercentage", data);
+            }}
+            value={data.germinationPercentage}
+          />
+        </Grid>
+        <Grid item xs={1}>
+          <Typography className="math-icon">÷</Typography>
+        </Grid>
+        <Grid item xs={3}>
+          <NumberTextField
+            className="text-field-100"
+            id="filled-basic"
+            label="% Purity"
+            variant="filled"
+            disabled={true}
+            value={data.purityPercentage}
+          />
+          <Typography className="font-15">Lbs / Acre</Typography>
+        </Grid>
+        <Grid container className="steps-row-2" xs={12}>
+          <Grid item xs={4}>
+            <Typography className="math-icon">=</Typography>
+          </Grid>
+          <Grid item xs={8}>
+            <NumberTextField
+              className="text-field-100"
+              id="filled-basic"
+              label="Bulk Seeding Rate"
+              variant="filled"
+              disabled={true}
+              value={data.bulkSeedingRate}
+            />
+          </Grid>
+        </Grid>
+        <Grid item xs={12}>
+          <Typography className="mix-ratio-step-header">Step 5: </Typography>
+        </Grid>
+        {renderStepsForm("Bulk Seeding Rate", "Acres", "Pounds for Purchase")}
+        <Grid item xs={3}>
+          <NumberTextField
+            className="text-field-100"
+            id="filled-basic"
+            label="Bulk Seeding Rate"
+            variant="filled"
+            disabled={true}
+            value={data.bulkSeedingRate}
+          />
+          <Typography className="font-15">Lbs / Acre</Typography>
+        </Grid>
+        <Grid item xs={1}>
+          <Typography className="math-icon">÷</Typography>
+        </Grid>
+        <Grid item xs={3}>
+          <NumberTextField
+            className="text-field-100"
+            id="filled-basic"
+            label="Acres"
+            variant="filled"
+            disabled={false}
+            handleChange={(e) => {
+              updateSeed(e.target.value, "acres", data);
+            }}
+            value={data.acres}
+          />
+        </Grid>
+        <Grid item xs={1}>
+          <Typography className="math-icon">=</Typography>
+        </Grid>
+        <Grid item xs={3}>
+          <NumberTextField
+            className="text-field-100"
+            id="filled-basic"
+            label="Pounds for Purchase"
+            variant="filled"
+            disabled={true}
+            value={data.poundsForPurchase}
+          />
+          <Typography>Lbs / Acre</Typography>
+        </Grid>
+      </Grid>
+    );
+  };
   return (
-    <Grid container justifyContent="center" alignItems="center">
-      <Typography variant="h2">Review Mix</Typography>
+    <Grid xs={12} container>
+      {renderSeedsSelected()}
+      <Grid
+        xs={12}
+        md={speciesSelection.seedsSelected.length > 0 ? 11 : 12}
+        item
+        justifyContent="center"
+        alignItems="center"
+      >
+        <Grid item xs={12}>
+          <Typography variant="h2">Review your mix</Typography>
+          <Grid container xs={12}>
+            <Grid item xs={6} md={6} className="mix-ratio-chart-container">
+              {renderPieChart("poundsOfSeed")}
+              <Typography className="mix-ratio-chart-header">
+                Pounds of Seed / Acre{" "}
+              </Typography>
+              <Grid item className="mix-ratio-chart-list-50">
+                {speciesSelection.seedsSelected.map((s, i) => {
+                  return (
+                    <Grid container xs={12}>
+                      <Grid item xs={2}>
+                        <Square sx={{ color: COLORS[i] }}></Square>
+                      </Grid>
+                      <Grid item xs={10}>
+                        <Typography className={matchesMd ? "mix-label-md" : ""}>
+                          {s.label}
+                        </Typography>
+                      </Grid>
+                    </Grid>
+                  );
+                })}
+              </Grid>
+            </Grid>
+            <Grid item xs={6} md={6} className="mix-ratio-chart-container">
+              {renderPieChart("plantsPerAcre")}
+              <Typography className="mix-ratio-chart-header">
+                Plants Per Acre{" "}
+              </Typography>
+              <Grid item className="mix-ratio-chart-list-50">
+                {speciesSelection.seedsSelected.map((s, i) => {
+                  return (
+                    <Grid container xs={12}>
+                      <Grid item xs={2}>
+                        <Square sx={{ color: COLORS[i] }}></Square>
+                      </Grid>
+                      <Grid item xs={10}>
+                        <Typography className={matchesMd ? "mix-label-md" : ""}>
+                          {s.label}
+                        </Typography>
+                      </Grid>
+                    </Grid>
+                  );
+                })}
+              </Grid>
+            </Grid>
+          </Grid>
+          <Grid container xs={12}>
+            {speciesSelection.seedsSelected.map((s, i) => {
+              return (
+                <Grid item xs={12}>
+                  {renderAccordian(s)}
+                </Grid>
+              );
+            })}
+          </Grid>
+        </Grid>
+      </Grid>
     </Grid>
   );
 };

--- a/src/pages/Calculator/Steps/ReviewMix.js
+++ b/src/pages/Calculator/Steps/ReviewMix.js
@@ -267,7 +267,7 @@ const ReviewMix = () => {
               <YAxis type="number" dataKey="y" name="weight" unit="lb" />
               <ZAxis dataKey="z" range={[1000, 1449]} name="score" unit="km" />
               <Tooltip cursor={{ strokeDasharray: "50 50" }} />
-              <Scatter name="A school" data={data} fill="#8884d8">
+              <Scatter name="A school" data={data} fill="#E7885F">
                 <LabelList dataKey="x" />
               </Scatter>
             </ScatterChart>

--- a/src/pages/Calculator/Steps/SeedingMethod.js
+++ b/src/pages/Calculator/Steps/SeedingMethod.js
@@ -200,12 +200,12 @@ const SeedingMethod = () => {
                 className="seeding-method-label-container"
                 sx={{ marginBottom: "270px" }}
               >
-                <Typography>Low limit of Mix Seeding Rate</Typography>
+                <Typography>High limit of Mix Seeding Rate</Typography>
               </Box>
             </Grid>
             <Grid item xs={12} justifyContent="flex-end">
               <Box className="seeding-method-label-container">
-                <Typography>High limit of Mix Seeding Rate</Typography>
+                <Typography>Low limit of Mix Seeding Rate</Typography>
               </Box>
             </Grid>
           </Grid>

--- a/src/pages/Calculator/Steps/SpeciesSelection.js
+++ b/src/pages/Calculator/Steps/SpeciesSelection.js
@@ -18,7 +18,7 @@ import { updateSteps } from "./../../../features/stepSlice";
 import { seedsList, seedsLabel } from "../../../shared/data/species";
 import airtable from "../../../shared/data/airtable.json";
 import {
-  calculateAllSteps,
+  calculateAllValues,
   calculateSeeds,
 } from "../../../shared/utils/calculate";
 import "./steps.css";
@@ -109,38 +109,62 @@ const SpeciesSelection = () => {
         };
       }
     });
+    // default key values per new seed
     let newSeed = {
       ...seed,
-      step1: {
-        singleSpeciesSeedingRatePLS: extData["singleSpeciesSeedingRatePLS"],
-        percentOfSingleSpeciesRate: extData["percentOfSingleSpeciesRate"],
-      },
-      step2: {
-        seedsPound: extData["seedsPound"],
-        mixSeedingRate: 0,
-      },
-      step3: {
-        seedsAcre: 0,
-        percentSurvival: extData["percentSurvival"],
-      },
-      step4: {
-        plantsAcre: 0,
-        sqFtAcre: 43560,
-      },
+      // step1: {
+      //   singleSpeciesSeedingRatePLS: extData["singleSpeciesSeedingRatePLS"],
+      //   percentOfSingleSpeciesRate: extData["percentOfSingleSpeciesRate"],
+      // },
+      // step2: {
+      //   seedsPound: extData["seedsPound"],
+      //   mixSeedingRate: 0,
+      // },
+      // step3: {
+      //   seedsAcre: 0,
+      //   percentSurvival: extData["percentSurvival"],
+      // },
+      // step4: {
+      //   plantsAcre: 0,
+      //   sqFtAcre: 43560,
+      // },
+      singleSpeciesSeedingRatePLS: extData["singleSpeciesSeedingRatePLS"],
+      percentOfSingleSpeciesRate: extData["percentOfSingleSpeciesRate"],
+      seedsPound: extData["seedsPound"],
+      mixSeedingRate: 0,
+      seedsAcre: 0,
+      percentSurvival: extData["percentSurvival"],
+      plantsAcre: 0,
+      sqFtAcre: 43560,
       germinationPercentage: extData["germinationPercentage"],
       purityPercentage: extData["purityPercentage"],
       seedsPerAcre: 0,
       poundsOfSeed: extData["poundsOfSeed"],
       plantsPerAcre: 0,
-      mixSeedingRate: 0,
       aproxPlantsSqFt: 0,
       precisionRowUnitPlanter: extData["precisionRowUnitPlanter"],
       broadcast: 0,
       drilled: 0,
       showSteps: false,
+      // Review your Mix new values
+      plantingMethod: 1,
+      managementImpactOnMix: 57,
+      mixSeedingRatePLS: 0,
+      bulkGerminationAndPurity: 0,
+      bulkSeedingRate: 0,
+      addedToMix: 0,
+      step1MixSeedingRate: 0,
+      step2MixSeedingRatePLS: 0,
+      step2Result: 0,
+      step3MixSeedingRatePLS: 0,
+      step3Result: 0,
+      step4MixSeedingRatePLS: 0,
+      step4Result: 0,
+      acres: 0,
+      poundsForPurchase: 0,
     };
     // edit logic in mix ratio => remove step2.seedsPound
-    newSeed = calculateAllSteps(newSeed);
+    newSeed = calculateAllValues(newSeed);
     if (seedsSelected.length === 0) {
       handleUpdateSteps("seedsSelected", [...seedsSelected, newSeed]);
       handleUpdateSteps("diversitySelected", [...diversitySelected, species]);

--- a/src/pages/Calculator/Steps/steps.css
+++ b/src/pages/Calculator/Steps/steps.css
@@ -225,6 +225,9 @@ site-condition-header {
 .text-field-50 {
     width: 50% !important;
 }
+.font-15 {
+    font-size: 15px;
+}
 .no-display {
     opacity: 0%;
 }
@@ -237,4 +240,10 @@ color: red;
 }
 .vertical-slider {
     margin-top: 70px
+}
+
+/* Steps */
+
+.steps-row-2 {
+    margin-top: 20px;
 }

--- a/src/shared/utils/calculate.js
+++ b/src/shared/utils/calculate.js
@@ -15,7 +15,9 @@ export const calculateInt = (nums, type) => {
   }
 };
 
-export const calculateAllSteps = (prevSeed) => {
+/* Mix Ratios Calculate Logic */
+
+export const calculateAllValues = (prevSeed) => {
   let seed = { ...prevSeed };
   seed.mixSeedingRate = calculateSeeds("step1", seed).val;
   seed.seedsPerAcre = calculateSeeds("step2", seed).val;
@@ -29,38 +31,103 @@ export const calculateSeeds = (step, seed) => {
       return {
         key: "mixSeedingRate",
         val: calculateInt(
-          [
-            seed.step1.singleSpeciesSeedingRatePLS,
-            seed.step1.percentOfSingleSpeciesRate,
-          ],
+          [seed.singleSpeciesSeedingRatePLS, seed.percentOfSingleSpeciesRate],
           "percentage"
         ),
       };
     case "step2":
       return {
         key: "seedsPerAcre",
-        val: calculateInt(
-          [seed.step2.seedsPound, seed.mixSeedingRate],
-          "multiply"
-        ),
+        val: calculateInt([seed.seedsPound, seed.mixSeedingRate], "multiply"),
       };
     case "step3":
       return {
         key: "plantsPerAcre",
         val: calculateInt(
-          [seed.seedsPerAcre, seed.step3.percentSurvival],
+          [seed.seedsPerAcre, seed.percentSurvival],
           "percentage"
         ),
       };
     case "step4":
       return {
         key: "aproxPlantsSqFt",
-        val: calculateInt([seed.plantsPerAcre, seed.step4.sqFtAcre], "divide"),
+        val: calculateInt([seed.plantsPerAcre, seed.sqFtAcre], "divide"),
       };
     default:
       return;
   }
 };
+
+/* Review Mix Calculate logic */
+
+export const calculateAllMixValues = (prevSeed) => {
+  let seed = { ...prevSeed };
+  seed.mixSeedingRate = calculateReviewMix("step1", seed).val;
+  seed.step2Result = calculateReviewMix("step2", seed).val;
+  seed.step3Result = calculateReviewMix("step3", seed).val;
+  seed.bulkSeedingRate = calculateReviewMix("step4", seed).val;
+  seed.poundsForPurchase = calculateReviewMix("step5", seed).val;
+  return seed;
+};
+
+export const calculateReviewMix = (step, seed) => {
+  switch (step) {
+    case "step1":
+      return {
+        key: "mixSeedingRate",
+        val: calculateInt(
+          [seed.singleSpeciesSeedingRatePLS, seed.percentOfSingleSpeciesRate],
+          "percentage"
+        ),
+      };
+    case "step2":
+      return {
+        key: "step2Result",
+        val: calculateInt(
+          [seed.step2MixSeedingRatePLS, seed.plantingMethod],
+          "multiply"
+        ),
+      };
+    case "step3":
+      return {
+        key: "step3Result",
+        val: calculateInt(
+          [
+            seed.step2Result,
+            calculateInt(
+              [seed.step3MixSeedingRatePLS, seed.managementImpactOnMix],
+              "multiply"
+            ),
+          ],
+          "divide"
+        ),
+      };
+    case "step4":
+      return {
+        key: "bulkSeedingRate",
+        val: calculateInt(
+          [
+            seed.step3Result,
+            calculateInt(
+              [seed.germinationPercentage, seed.purityPercentage],
+              "divide"
+            ),
+          ],
+          "divide"
+        ),
+      };
+    case "step5":
+      return {
+        key: "poundsForPurchase",
+        val: calculateInt([seed.bulkSeedingRate, seed.acres], "divide"),
+      };
+    default:
+      return;
+  }
+};
+
+/* Review mix end */
+
 export const isNumeric = (str) => {
   if (typeof str != "string") return false;
   return !isNaN(str) && !isNaN(parseFloat(str));


### PR DESCRIPTION
Review Mix page

Features:
- Pie chart displaying percentage of selected seeds
- Scatter graph  displaying Lbs/acre bulk seed usage
- Listed sum of all seed's (Single Species Seeding Rate, Added to Mix, Drilled or Broadcast, Management Impacts on Mix, Bulk Germination & Purity)
- 5 steps of calculations (TODO: polish step 3 & step 4 form style)


Changes on other pages:

- Changed Species Selection's seed data format (removed steps layer, allowing all data to be accessed in 1 layer rather than deeply nested values)
- Reworked some calculation logic
- Reworked the re-usable Redux update function 

Notes:

- Same as the Mix Ratios page, the forms & logic takes up hundreds of lines of code. Confirm plan will run into this too but I plan to modularize these page into separate components after I finish up the core features of the application.
- Lots of manually added data, but the logic checks out per step calculation.


Expected Results:
![Screen Shot 2023-02-13 at 9 38 59 AM](https://user-images.githubusercontent.com/23531153/218567401-b3cce645-d4eb-4d32-bbfa-1bbd7dc4e9cb.png)
![Screen Shot 2023-02-13 at 9 38 49 AM](https://user-images.githubusercontent.com/23531153/218567409-e57cc451-60fb-4f99-95a5-dfc9590ffb9a.png)

