### PR TITLE
Update Seed Tag Info

### DIFF
--- a/src/components/StepsList/index.js
+++ b/src/components/StepsList/index.js
@@ -105,7 +105,7 @@ const StepsList = ({ activeStep, setActiveStep, availableSteps }) => {
                 : activeStep === 1 && !availableSteps[1]
                   ? 'Please select at least 2 plants.'
                   : activeStep === 5 && !availableSteps[5]
-                    ? 'Please make selection for all seeds'
+                    ? 'Please make a selection.'
                     : ''
             }
             open

--- a/src/components/StepsList/index.js
+++ b/src/components/StepsList/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-nested-ternary */
 import React, { useState } from 'react';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
@@ -47,6 +48,7 @@ const StepsList = ({ activeStep, setActiveStep, availableSteps }) => {
   };
 
   const handleReset = () => {
+    // TODO: add function to clear redux
     setActiveStep(0);
     setCompletedStep(-1);
   };
@@ -98,13 +100,15 @@ const StepsList = ({ activeStep, setActiveStep, availableSteps }) => {
           <Tooltip
             arrow
             title={
-              // eslint-disable-next-line no-nested-ternary
               activeStep === 0 && !availableSteps[0]
                 ? 'Please enter the necessary info below.'
                 : activeStep === 1 && !availableSteps[1]
                   ? 'Please select at least 2 plants.'
-                  : ''
+                  : activeStep === 5 && !availableSteps[5]
+                    ? 'Please make selection for all seeds'
+                    : ''
             }
+            open
           >
             <span>
               <Button

--- a/src/pages/Calculator/Steps/SeedTagInfo/index.js
+++ b/src/pages/Calculator/Steps/SeedTagInfo/index.js
@@ -5,11 +5,13 @@
 import React, { useState, useEffect } from 'react';
 import Grid from '@mui/material/Grid';
 import { useSelector, useDispatch } from 'react-redux';
-import { Typography } from '@mui/material';
+import { Button, Typography } from '@mui/material';
 import Accordion from '@mui/material/Accordion';
 import AccordionSummary from '@mui/material/AccordionSummary';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import CheckIcon from '@mui/icons-material/Check';
+import CloseIcon from '@mui/icons-material/Close';
 
 import styled from '@emotion/styled';
 import NumberTextField from '../../../../components/NumberTextField';
@@ -34,6 +36,13 @@ const SeedTagInfo = () => {
   const [accordionState, setAccordionState] = useState(
     seedsSelected.reduce((res, seed) => {
       res[seed.label] = true;
+      return res;
+    }, {}),
+  );
+
+  const [haveSeedTagInfo, setHaveSeedTagInfo] = useState(
+    seedsSelected.reduce((res, seed) => {
+      res[seed.label] = false;
       return res;
     }, {}),
   );
@@ -97,47 +106,80 @@ const SeedTagInfo = () => {
               <Typography>{seed.label}</Typography>
             </AccordionSummary>
             <AccordionDetails className="accordian-details">
-              <Grid container>
 
-                <LeftGrid item xs={6}>
-                  <Typography>% Germination: </Typography>
-                </LeftGrid>
-                <Grid item xs={4}>
-                  <NumberTextField
-                    value={(options[seed.label].germination ?? 0.85) * 100}
-                    handleChange={(e) => {
-                      updateGermination(seed.label, parseFloat(e.target.value) / 100);
-                    }}
-                  />
+              {haveSeedTagInfo[seed.label] === false
+                && (
+                <Grid container sx={{ padding: '1rem 0' }}>
+                  <Grid item xs={12} md={8}>
+                    <Typography>
+                      {`Do you have seed tag info for ${seed.label}?`}
+                    </Typography>
+                  </Grid>
+                  <Grid item xs={12} md={4} display="flex" justifyContent="center" gap="1rem">
+                    <Button
+                      variant="outlined"
+                      onClick={() => setHaveSeedTagInfo({ ...haveSeedTagInfo, [seed.label]: true })}
+                    >
+                      Yes
+                      {' '}
+                      <CheckIcon color="primary.dark" />
+                    </Button>
+                    <Button
+                      variant="outlined"
+                      onClick={() => setHaveSeedTagInfo({ ...haveSeedTagInfo, [seed.label]: true })}
+                    >
+                      No
+                      {' '}
+                      <CloseIcon color="error" />
+                    </Button>
+                  </Grid>
                 </Grid>
-                <Grid item xs={2} />
+                )}
+              {haveSeedTagInfo[seed.label] === true
+                && (
+                <Grid container>
 
-                <LeftGrid item xs={6}>
-                  <Typography>% Purity: </Typography>
-                </LeftGrid>
-                <Grid item xs={4}>
-                  <NumberTextField
-                    value={(options[seed.label].purity ?? 0.9) * 100}
-                    handleChange={(e) => {
-                      updatePurity(seed.label, parseFloat(e.target.value) / 100);
-                    }}
-                  />
-                </Grid>
-                <Grid item xs={2} />
+                  <LeftGrid item xs={6}>
+                    <Typography>% Germination: </Typography>
+                  </LeftGrid>
+                  <Grid item xs={4}>
+                    <NumberTextField
+                      value={(options[seed.label].germination ?? 0.85) * 100}
+                      handleChange={(e) => {
+                        updateGermination(seed.label, parseFloat(e.target.value) / 100);
+                      }}
+                    />
+                  </Grid>
+                  <Grid item xs={2} />
 
-                <LeftGrid item xs={6}>
-                  <Typography>Seeds per Pound </Typography>
-                </LeftGrid>
-                <Grid item xs={4}>
-                  <NumberTextField
-                    value={seedsPerPound(seed)}
-                    handleChange={(e) => {
-                      updateSeedsPerPound(seed.label, parseFloat(e.target.value));
-                    }}
-                  />
+                  <LeftGrid item xs={6}>
+                    <Typography>% Purity: </Typography>
+                  </LeftGrid>
+                  <Grid item xs={4}>
+                    <NumberTextField
+                      value={(options[seed.label].purity ?? 0.9) * 100}
+                      handleChange={(e) => {
+                        updatePurity(seed.label, parseFloat(e.target.value) / 100);
+                      }}
+                    />
+                  </Grid>
+                  <Grid item xs={2} />
+
+                  <LeftGrid item xs={6}>
+                    <Typography>Seeds per Pound </Typography>
+                  </LeftGrid>
+                  <Grid item xs={4}>
+                    <NumberTextField
+                      value={seedsPerPound(seed)}
+                      handleChange={(e) => {
+                        updateSeedsPerPound(seed.label, parseFloat(e.target.value));
+                      }}
+                    />
+                  </Grid>
+                  <Grid item xs={2} />
                 </Grid>
-                <Grid item xs={2} />
-              </Grid>
+                )}
+
             </AccordionDetails>
           </Accordion>
         </Grid>

--- a/src/pages/Calculator/Steps/SeedTagInfo/index.js
+++ b/src/pages/Calculator/Steps/SeedTagInfo/index.js
@@ -41,12 +41,7 @@ const SeedTagInfo = ({ completedStep, setCompletedStep }) => {
     }, {}),
   );
 
-  const [haveSeedTagInfo, setHaveSeedTagInfo] = useState(
-    seedsSelected.reduce((res, seed) => {
-      res[seed.label] = false;
-      return res;
-    }, {}),
-  );
+  const [haveSeedTagInfo, setHaveSeedTagInfo] = useState(false);
 
   const updateGermination = (seedLabel, value) => {
     dispatch(setOptionRedux(seedLabel, { ...options[seedLabel], germination: value }));
@@ -89,63 +84,50 @@ const SeedTagInfo = ({ completedStep, setCompletedStep }) => {
   }, []);
 
   useEffect(() => {
-    let complete = true;
-    seedsSelected.forEach((seed) => {
-      complete &&= haveSeedTagInfo[seed.label];
-    });
-    validateForms(complete, 5, completedStep, setCompletedStep);
+    validateForms(haveSeedTagInfo, 5, completedStep, setCompletedStep);
   }, [haveSeedTagInfo]);
 
   return (
     <Grid container>
       <Grid item xs={12}>
-        <Typography variant="h2">Enter seed tag info</Typography>
+        <Typography variant="h2">{haveSeedTagInfo ? 'Enter seed tag info' : 'Do you have seed tag info?'}</Typography>
       </Grid>
-
-      {seedsSelected.map((seed, i) => (
-        <Grid item xs={12} key={i}>
-          <Accordion
-            expanded={accordionState[seed.label]}
-            onChange={() => handleExpandAccordion(seed.label)}
-          >
-            <AccordionSummary
-              expandIcon={<ExpandMoreIcon />}
-              className="accordian-summary"
+      {haveSeedTagInfo === false
+        && (
+        <Grid container sx={{ padding: '1rem' }}>
+          <Grid item xs={12} display="flex" justifyContent="center" gap="1rem">
+            <Button
+              variant="outlined"
+              onClick={() => setHaveSeedTagInfo(true)}
             >
-              <Typography>{seed.label}</Typography>
-            </AccordionSummary>
-            <AccordionDetails className="accordian-details">
+              Yes
+              <CheckIcon color="primary.dark" />
+            </Button>
+            <Button
+              variant="outlined"
+              onClick={() => setHaveSeedTagInfo(true)}
+            >
+              No
+              <CloseIcon color="error" />
+            </Button>
+          </Grid>
+        </Grid>
+        )}
+      {haveSeedTagInfo === true
+        && (seedsSelected.map((seed, i) => (
+          <Grid item xs={12} key={i}>
+            <Accordion
+              expanded={accordionState[seed.label]}
+              onChange={() => handleExpandAccordion(seed.label)}
+            >
+              <AccordionSummary
+                expandIcon={<ExpandMoreIcon />}
+                className="accordian-summary"
+              >
+                <Typography>{seed.label}</Typography>
+              </AccordionSummary>
+              <AccordionDetails className="accordian-details">
 
-              {haveSeedTagInfo[seed.label] === false
-                && (
-                <Grid container sx={{ padding: '1rem 0' }}>
-                  <Grid item xs={12} md={8}>
-                    <Typography>
-                      {`Do you have seed tag info for ${seed.label}?`}
-                    </Typography>
-                  </Grid>
-                  <Grid item xs={12} md={4} display="flex" justifyContent="center" gap="1rem">
-                    <Button
-                      variant="outlined"
-                      onClick={() => setHaveSeedTagInfo({ ...haveSeedTagInfo, [seed.label]: true })}
-                    >
-                      Yes
-                      {' '}
-                      <CheckIcon color="primary.dark" />
-                    </Button>
-                    <Button
-                      variant="outlined"
-                      onClick={() => setHaveSeedTagInfo({ ...haveSeedTagInfo, [seed.label]: true })}
-                    >
-                      No
-                      {' '}
-                      <CloseIcon color="error" />
-                    </Button>
-                  </Grid>
-                </Grid>
-                )}
-              {haveSeedTagInfo[seed.label] === true
-                && (
                 <Grid container>
 
                   <LeftGrid item xs={6}>
@@ -187,12 +169,11 @@ const SeedTagInfo = ({ completedStep, setCompletedStep }) => {
                   </Grid>
                   <Grid item xs={2} />
                 </Grid>
-                )}
 
-            </AccordionDetails>
-          </Accordion>
-        </Grid>
-      ))}
+              </AccordionDetails>
+            </Accordion>
+          </Grid>
+        )))}
     </Grid>
   );
 };

--- a/src/pages/Calculator/Steps/SeedTagInfo/index.js
+++ b/src/pages/Calculator/Steps/SeedTagInfo/index.js
@@ -29,11 +29,11 @@ const LeftGrid = styled(Grid)({
 const SeedTagInfo = () => {
   const dispatch = useDispatch();
   const { council } = useSelector((state) => state.siteCondition);
-  const { sideBarSelection, seedsSelected, options } = useSelector((state) => state.calculator);
+  const { seedsSelected, options } = useSelector((state) => state.calculator);
 
   const [accordionState, setAccordionState] = useState(
     seedsSelected.reduce((res, seed) => {
-      res[seed.label] = false;
+      res[seed.label] = true;
       return res;
     }, {}),
   );
@@ -44,6 +44,17 @@ const SeedTagInfo = () => {
 
   const updatePurity = (seedLabel, value) => {
     dispatch(setOptionRedux(seedLabel, { ...options[seedLabel], purity: value }));
+  };
+
+  const updateSeedsPerPound = (seedLabel, value) => {
+    dispatch(setOptionRedux(seedLabel, { ...options[seedLabel], seedsPerPound: value }));
+  };
+
+  const seedsPerPound = (seed) => {
+    if (options[seed.label].seedsPerPound) return options[seed.label].seedsPerPound;
+    if (council === 'MCCC') return seed.attributes['Planting Information']['Seed Count'].values[0];
+    if (council === 'NECCC') return seed.attributes.Planting['Seeds Per lb'].values[0];
+    return '';
   };
 
   const handleExpandAccordion = (label) => {
@@ -66,16 +77,6 @@ const SeedTagInfo = () => {
       dispatch(setOptionRedux(seed.label, { ...options[seed.label], germination, purity }));
     });
   }, []);
-
-  useEffect(() => {
-    // expand related accordion based on sidebar click
-    setAccordionState(
-      seedsSelected.reduce((res, seed) => {
-        res[seed.label] = seed.label === sideBarSelection;
-        return res;
-      }, {}),
-    );
-  }, [sideBarSelection]);
 
   return (
     <Grid container>
@@ -129,10 +130,10 @@ const SeedTagInfo = () => {
                 </LeftGrid>
                 <Grid item xs={4}>
                   <NumberTextField
-                    disabled
-                    value={parseFloat(council === 'MCCC'
-                      ? seed.attributes['Planting Information']['Seed Count'].values[0]
-                      : seed.attributes.Planting['Seeds Per lb'].values[0])}
+                    value={seedsPerPound(seed)}
+                    handleChange={(e) => {
+                      updateSeedsPerPound(seed.label, parseFloat(e.target.value));
+                    }}
                   />
                 </Grid>
                 <Grid item xs={2} />

--- a/src/pages/Calculator/Steps/SeedTagInfo/index.js
+++ b/src/pages/Calculator/Steps/SeedTagInfo/index.js
@@ -17,6 +17,7 @@ import styled from '@emotion/styled';
 import NumberTextField from '../../../../components/NumberTextField';
 import { setOptionRedux } from '../../../../features/calculatorSlice/actions';
 import '../steps.scss';
+import { validateForms } from '../../../../shared/utils/format';
 
 const LeftGrid = styled(Grid)({
   '&.MuiGrid-item': {
@@ -28,7 +29,7 @@ const LeftGrid = styled(Grid)({
   },
 });
 
-const SeedTagInfo = () => {
+const SeedTagInfo = ({ completedStep, setCompletedStep }) => {
   const dispatch = useDispatch();
   const { council } = useSelector((state) => state.siteCondition);
   const { seedsSelected, options } = useSelector((state) => state.calculator);
@@ -86,6 +87,14 @@ const SeedTagInfo = () => {
       dispatch(setOptionRedux(seed.label, { ...options[seed.label], germination, purity }));
     });
   }, []);
+
+  useEffect(() => {
+    let complete = true;
+    seedsSelected.forEach((seed) => {
+      complete &&= haveSeedTagInfo[seed.label];
+    });
+    validateForms(complete, 5, completedStep, setCompletedStep);
+  }, [haveSeedTagInfo]);
 
   return (
     <Grid container>

--- a/src/pages/Calculator/index.js
+++ b/src/pages/Calculator/index.js
@@ -83,7 +83,10 @@ const Calculator = () => {
         );
       case 'Seed Tag Info':
         return (
-          <SeedTagInfo />
+          <SeedTagInfo
+            completedStep={completedStep}
+            setCompletedStep={setCompletedStep}
+          />
         );
       case 'Review Mix':
         return (

--- a/src/shared/data/dropdown.js
+++ b/src/shared/data/dropdown.js
@@ -17,7 +17,7 @@ export const calculatorList = [
   'Review Mix',
   'Confirm Plan',
 ];
-export const completedList = [false, false, true, true, true, true, true, true];
+export const completedList = [false, false, true, true, true, false, true, true];
 
 export const availableStates = [
   'Connecticut',


### PR DESCRIPTION
- Default expands every seed, add a selection 'Do you have seed tag info?' for each of them.
- Update stepper to disable next button unless all seeds are selected yes or no.
- Enable editing seed per pound.

closes #143