### PR TITLE
Update stepper logic

### DIFF
--- a/src/components/StepsList/index.js
+++ b/src/components/StepsList/index.js
@@ -4,11 +4,14 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import Box from '@mui/material/Box';
 import Stepper from '@mui/material/Stepper';
 import Step from '@mui/material/Step';
-import { StepButton, Tooltip } from '@mui/material';
+import { StepLabel, Tooltip } from '@mui/material';
 import Button from '@mui/material/Button';
 import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
-import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
+// import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
+import RestartAltIcon from '@mui/icons-material/RestartAlt';
+import { useDispatch } from 'react-redux';
 import { calculatorList } from '../../shared/data/dropdown';
+import { resetCalculator } from '../../features/calculatorSlice';
 
 /*
 {
@@ -30,6 +33,8 @@ const StepsList = ({ activeStep, setActiveStep, availableSteps }) => {
   const theme = useTheme();
   const matches = useMediaQuery(theme.breakpoints.up('sm'));
 
+  const dispatch = useDispatch();
+
   // this completed step is to determine the latest completed step
   const [completedStep, setCompletedStep] = useState(-1);
 
@@ -42,62 +47,58 @@ const StepsList = ({ activeStep, setActiveStep, availableSteps }) => {
     setCompletedStep(activeStep > completedStep ? activeStep : completedStep);
   };
 
-  const handleBack = () => {
-    setActiveStep((prevActiveStep) => prevActiveStep - 1);
-  };
+  // const handleBack = () => {
+  //   setActiveStep((prevActiveStep) => prevActiveStep - 1);
+  // };
 
-  const handleReset = () => {
+  const handleRestart = () => {
     setActiveStep(0);
     setCompletedStep(-1);
+    dispatch(resetCalculator());
   };
 
   return (
     <Box sx={{ color: 'primary.text' }}>
       <Stepper activeStep={activeStep} alternativeLabel nonLinear>
         {calculatorList.map((label, index) => (
-          <Step key={label} disabled={completedStep + 1 < index}>
-            <StepButton
-              onClick={() => setActiveStep(index)}
-              sx={{
-                '& .MuiSvgIcon-root': {
-                  color: completedStep + 1 < index ? '' : '#4f5f30',
-                  '&.Mui-active': {
-                    color: '#77b400',
-                  },
+          <Step
+            key={label}
+            sx={{
+              '& .MuiSvgIcon-root': {
+                color: completedStep + 1 < index ? '' : '#4f5f30',
+                '&.Mui-active': {
+                  color: '#77b400',
                 },
-                '& .MuiStepLabel-label': {
-                  '&.Mui-active,&.Mui-completed': {
-                    color: 'primary.text',
-                  },
+              },
+              '& .MuiStepLabel-label': {
+                '&.Mui-active,&.Mui-completed': {
+                  color: 'primary.text',
                 },
-              }}
-            >
+              },
+            }}
+          >
+            <StepLabel>
               {matches && label}
-            </StepButton>
+            </StepLabel>
           </Step>
         ))}
       </Stepper>
 
       <Box sx={{ display: 'flex', flexDirection: 'row', pt: 1 }}>
         {activeStep !== 0 && (
-          <Button variant="stepper" onClick={handleBack}>
-            <ArrowBackIosNewIcon />
-            {activeStep === calculatorList.length
-              ? 'BACK'
-              : calculatorList[activeStep - 1]}
+          <Button variant="stepper" onClick={handleRestart}>
+            <RestartAltIcon />
+            Restart
           </Button>
         )}
 
         <Box sx={{ flex: '1 1 auto' }} />
 
-        {activeStep === calculatorList.length ? (
-          <Button variant="stepper" onClick={handleReset}>
-            Reset
-          </Button>
-        ) : (
-          <Tooltip
-            arrow
-            title={
+        {activeStep !== calculatorList.length
+        && (
+        <Tooltip
+          arrow
+          title={
               // eslint-disable-next-line no-nested-ternary
               activeStep === 0 && !availableSteps[0]
                 ? 'Please enter the necessary info below.'
@@ -105,21 +106,21 @@ const StepsList = ({ activeStep, setActiveStep, availableSteps }) => {
                   ? 'Please select at least 2 plants.'
                   : ''
             }
-          >
-            <span>
-              <Button
-                variant="stepper"
-                disabled={availableSteps[activeStep] !== true}
-                onClick={handleNext}
-              >
-                {activeStep === calculatorList.length - 1
-                  ? 'Finish'
-                  : calculatorList[activeStep + 1]}
-                {' '}
-                <ArrowForwardIosIcon />
-              </Button>
-            </span>
-          </Tooltip>
+        >
+          <span>
+            <Button
+              variant="stepper"
+              disabled={availableSteps[activeStep] !== true}
+              onClick={handleNext}
+            >
+              {activeStep === calculatorList.length - 1
+                ? 'Finish'
+                : calculatorList[activeStep + 1]}
+              {' '}
+              <ArrowForwardIosIcon />
+            </Button>
+          </span>
+        </Tooltip>
         )}
       </Box>
     </Box>

--- a/src/features/calculatorSlice/index.js
+++ b/src/features/calculatorSlice/index.js
@@ -55,6 +55,7 @@ const calculatorSlice = createSlice({
       const { csvData } = payload;
       return { ...csvData };
     },
+    resetCalculator: () => initialState,
   },
   extraReducers: (builder) => {
     builder
@@ -78,6 +79,7 @@ export const {
   addSeed, removeSeed, setOption, removeOption, updateDiversity,
   clearSeeds, clearOptions, selectSidebarSeed, setMixSeedingRate,
   setBulkSeedingRate, setAdjustedMixSeedingRate, importFromCSV,
+  resetCalculator,
 } = calculatorSlice.actions;
 
 export default calculatorSlice;


### PR DESCRIPTION
- Removed going back function.
- Add a restart button on each page, when click restart, the app would return to site condition page with previously selected params.
- Disabled clicking on steps.
- The skip over changing ratios, seeding rate, seed tag function is not available to implement currently since the step button is disabled.

closes #142 
