### PR TITLE
Update mix ratio design

### DIFF
--- a/src/components/NumberTextField/index.js
+++ b/src/components/NumberTextField/index.js
@@ -11,14 +11,13 @@ const NumberTextField = ({
 }) => (
   <TextField
     fullWidth
-    value={value}
+    value={value.toLocaleString()}
     label={label}
     onChange={handleChange}
     InputLabelProps={{
       shrink: true,
     }}
     InputProps={InputProps}
-    type="number"
     placeholder={placeholder}
     disabled={disabled}
   />

--- a/src/components/NumberTextField/index.js
+++ b/src/components/NumberTextField/index.js
@@ -21,7 +21,6 @@ const NumberTextField = ({
     type="number"
     placeholder={placeholder}
     disabled={disabled}
-    sx={{ backgroundColor: disabled ? 'WhiteSmoke' : '' }}
   />
 );
 

--- a/src/components/SeedingRateCard/index.js
+++ b/src/components/SeedingRateCard/index.js
@@ -193,7 +193,7 @@ const SeedInfo = ({
         && (
         <>
           <Grid item xs={12} pt="1rem">
-            <Typography textAlign="left">
+            <Typography>
               {`% of Single Species Rate: ${singleSpeciesRate}%`}
             </Typography>
             <Slider
@@ -206,7 +206,7 @@ const SeedInfo = ({
             />
           </Grid>
           <Grid item xs={12}>
-            <Typography textAlign="left">
+            <Typography>
               {`% Survival: ${survival}%`}
             </Typography>
             <Slider
@@ -223,7 +223,7 @@ const SeedInfo = ({
 
         {council === 'NECCC' && (
         <Grid item xs={12} pt="1rem">
-          <Typography textAlign="left">
+          <Typography>
             {`Single Species Seeding Rate PLS: ${singleSpeciesSeedingRate} Lbs per Acre`}
           </Typography>
           <Slider

--- a/src/components/SeedingRateCard/index.js
+++ b/src/components/SeedingRateCard/index.js
@@ -1,19 +1,18 @@
 import React, { useState, useEffect } from 'react';
 import {
-  Typography, Box, Button, Tooltip,
+  Typography, Box, Button, Grid, Card, CardContent, CardMedia,
 } from '@mui/material';
 import { useDispatch, useSelector } from 'react-redux';
-import HelpIcon from '@mui/icons-material/Help';
 import { twoDigit } from '../../shared/utils/calculator';
 import { selectUnitRedux } from '../../features/calculatorSlice/actions';
 
-const tooltipMCCC = {
-  mixSeedingRate: 'Seeding Rate in Mix = Default Single Species Seeding Rate PLS * Percent of Rate',
-};
+// const tooltipMCCC = {
+//   mixSeedingRate: 'Seeding Rate in Mix = Default Single Species Seeding Rate PLS * Percent of Rate',
+// };
 
-const tooltipNECCC = {
-  mixSeedingRate: 'Seeding Rate in Mix = Default Single Species Seeding Rate PLS *  Soil Fertility Modifier / Sum Species Of Group in Mix',
-};
+// const tooltipNECCC = {
+//   mixSeedingRate: 'Seeding Rate in Mix = Default Single Species Seeding Rate PLS *  Soil Fertility Modifier / Sum Species Of Group in Mix',
+// };
 
 const roundToMillionth = (num) => {
   const million = 10 ** 6;
@@ -45,13 +44,172 @@ const UnitSelection = () => {
   );
 };
 
+const SeedInfo = ({
+  seed, seedData, calculatorResult,
+}) => {
+  const [singleData, setSingleData] = useState({
+    seedingRate: calculatorResult[seed.label].step1.defaultSingleSpeciesSeedingRatePLS,
+    plantValue: seedData[seed.label].defaultPlant,
+    seedValue: seedData[seed.label].defaultSeed,
+  });
+  const [mixData, setMixData] = useState({
+    seedingRate: calculatorResult[seed.label].step1.seedingRate,
+    plantValue: seedData[seed.label].adjustedPlant,
+    seedValue: seedData[seed.label].adjustedSeed,
+  });
+
+  const { unit } = useSelector((state) => state.calculator);
+
+  // eslint-disable-next-line no-nested-ternary
+  const unitText = unit === 'acre' ? 'Acre' : unit === 'sqft' ? 'SqFt' : '';
+
+  useEffect(() => {
+    if (unit === 'sqft') {
+      setSingleData((prev) => ({
+        ...prev,
+        seedingRate: roundToMillionth(calculatorResult[seed.label].step1.defaultSingleSpeciesSeedingRatePLS / 43560),
+        plantValue: twoDigit(seedData[seed.label].defaultPlant / 43560),
+        seedValue: twoDigit(seedData[seed.label].defaultSeed / 43560),
+      }));
+      setMixData({
+        seedingRate: roundToMillionth(calculatorResult[seed.label].step1.seedingRate / 43560),
+        plantValue: twoDigit(seedData[seed.label].adjustedPlant / 43560),
+        seedValue: twoDigit(seedData[seed.label].adjustedSeed / 43560),
+      });
+    } else if (unit === 'acre') {
+      setSingleData((prev) => ({
+        ...prev,
+        seedingRate: calculatorResult[seed.label].step1.defaultSingleSpeciesSeedingRatePLS,
+        plantValue: seedData[seed.label].defaultPlant,
+        seedValue: seedData[seed.label].defaultSeed,
+      }));
+      setMixData({
+        seedingRate: calculatorResult[seed.label].step1.seedingRate,
+        plantValue: seedData[seed.label].adjustedPlant,
+        seedValue: seedData[seed.label].adjustedSeed,
+      });
+    }
+  }, [seedData, calculatorResult, unit]);
+
+  return (
+    <Grid container p="0 5%">
+      <Grid item xs={4}>
+        <Card
+          sx={{
+            backgroundColor: 'transparent',
+            border: 'none',
+            boxShadow: 'none',
+            width: '160px',
+          }}
+        >
+          <CardContent>
+            <Typography sx={{ fontWeight: 'bold' }}>
+              {seed.label}
+            </Typography>
+          </CardContent>
+          <CardMedia
+            component="img"
+            height="160px"
+            image={
+                  seed.thumbnail
+                  ?? 'https://placehold.it/250x150?text=Placeholder'
+                }
+            alt={seed.label}
+            sx={{ border: '2px solid green', borderRadius: '1rem' }}
+          />
+        </Card>
+      </Grid>
+      <Grid item xs={8}>
+        <Grid container>
+          <Grid item xs={4}>
+            <SeedingRateChip
+              label="Default Single Species Seeding Rate PLS"
+              value={singleData.seedingRate}
+              unit={unit === 'acre' ? '1000Acres' : unitText}
+            />
+          </Grid>
+          <Grid item xs={4}>
+            <SeedingRateChip
+              label="Approx Plants"
+              value={singleData.plantValue}
+              unit={unitText}
+            />
+          </Grid>
+          <Grid item xs={4}>
+            <SeedingRateChip
+              label="Seeds"
+              value={singleData.seedValue}
+              unit={unitText}
+            />
+          </Grid>
+        </Grid>
+        <Grid container>
+          <Grid item xs={4}>
+            <SeedingRateChip
+              label="Seeding Rate in Mix"
+              value={mixData.seedingRate}
+              unit={unit === 'acre' ? '1000Acres' : unitText}
+            />
+          </Grid>
+          <Grid item xs={4}>
+            <SeedingRateChip
+              label="Approx Plants"
+              value={mixData.plantValue}
+              unit={unitText}
+            />
+          </Grid>
+          <Grid item xs={4}>
+            <SeedingRateChip
+              label="Seeds"
+              value={mixData.seedValue}
+              unit={unitText}
+            />
+          </Grid>
+        </Grid>
+        <Grid item xs={12}>
+          <Typography textAlign="left">% of Single Species Rate</Typography>
+          {/* <Slider /> */}
+        </Grid>
+        <Grid item xs={12}>
+          <Typography textAlign="left">% Survival</Typography>
+          {/* <Slider /> */}
+        </Grid>
+      </Grid>
+    </Grid>
+  );
+};
+
+const SeedingRateChip = ({ label, value, unit }) => (
+  <>
+    <Box
+      sx={{
+        width: '110px',
+        height: '50px',
+        padding: '11px',
+        margin: '0 auto',
+        backgroundColor: '#E5E7D5',
+        border: '#C7C7C7 solid 1px',
+        borderRadius: '16px',
+      }}
+    >
+      <Typography>{value}</Typography>
+    </Box>
+    <Box sx={{ height: '2rem' }}>
+      <Typography lineHeight="1rem" fontSize="0.8rem">
+        {label}
+        {` per ${unit}`}
+      </Typography>
+    </Box>
+
+  </>
+);
+
 const SeedingRateCard = ({
-  seedingRateLabel, seedingRateValue, plantValue, seedValue, showTooltip = false,
+  seedingRateLabel, seedingRateValue, plantValue, seedValue,
 }) => {
   // default value is always seeds/palnts per acre
   const [displayValue, setDisplayValue] = useState({ plantValue, seedValue, seedingRateValue });
 
-  const council = useSelector((state) => state.siteCondition.council);
   const unit = useSelector((state) => state.calculator.unit);
 
   // eslint-disable-next-line no-nested-ternary
@@ -73,24 +231,6 @@ const SeedingRateCard = ({
     <>
       <Typography display="flex" alignItems="center" justifyContent="center">
         {seedingRateLabel}
-        {showTooltip !== false && (
-        <Tooltip
-          title={(
-            <>
-              <Typography style={{ color: '#FFFFF2' }}>
-                How is this calculated?
-              </Typography>
-              <Typography style={{ color: '#FFFFF2' }}>
-                {council === 'MCCC' ? tooltipMCCC[showTooltip] : tooltipNECCC[showTooltip]}
-              </Typography>
-            </>
-        )}
-          arrow
-          enterTouchDelay={0}
-        >
-          <HelpIcon />
-        </Tooltip>
-        )}
 
       </Typography>
       <Box
@@ -153,5 +293,5 @@ const SeedingRateCard = ({
   );
 };
 
-export { UnitSelection };
+export { UnitSelection, SeedInfo };
 export default SeedingRateCard;

--- a/src/components/SeedingRateCard/index.js
+++ b/src/components/SeedingRateCard/index.js
@@ -19,6 +19,12 @@ const roundToMillionth = (num) => {
   return Math.round(num * million) / (million / 1000);
 };
 
+const formatToHundredth = (num) => {
+  if (num < 100) return num;
+  const res = Math.round((num / 100)) * 100;
+  return res.toLocaleString();
+};
+
 const UnitSelection = () => {
   const unit = useSelector((state) => state.calculator.unit);
   const dispatch = useDispatch();
@@ -127,10 +133,10 @@ const SeedInfo = ({
             <SeedingRateChip value={singleData.seedingRate} />
           </Grid>
           <Grid item xs={4}>
-            <SeedingRateChip value={singleData.plantValue} />
+            <SeedingRateChip value={formatToHundredth(singleData.plantValue)} />
           </Grid>
           <Grid item xs={4}>
-            <SeedingRateChip value={singleData.seedValue} />
+            <SeedingRateChip value={formatToHundredth(singleData.seedValue)} />
           </Grid>
           <Grid item xs={4}>
             <SeedLabel
@@ -157,10 +163,10 @@ const SeedInfo = ({
             <SeedingRateChip value={mixData.seedingRate} />
           </Grid>
           <Grid item xs={4}>
-            <SeedingRateChip value={mixData.plantValue} />
+            <SeedingRateChip value={formatToHundredth(mixData.plantValue)} />
           </Grid>
           <Grid item xs={4}>
-            <SeedingRateChip value={mixData.seedValue} />
+            <SeedingRateChip value={formatToHundredth(mixData.seedValue)} />
           </Grid>
           <Grid item xs={4}>
             <SeedLabel
@@ -295,7 +301,7 @@ const SeedingRateCard = ({
           borderRadius: '16px',
         }}
       >
-        <Typography>{twoDigit(displayValue.plantValue)}</Typography>
+        <Typography>{formatToHundredth(twoDigit(displayValue.plantValue))}</Typography>
       </Box>
       <Typography>
         Approx Plants Per
@@ -314,7 +320,7 @@ const SeedingRateCard = ({
           borderRadius: '16px',
         }}
       >
-        <Typography>{twoDigit(displayValue.seedValue)}</Typography>
+        <Typography>{formatToHundredth(twoDigit(displayValue.seedValue))}</Typography>
       </Box>
       <Typography>
         Seeds Per

--- a/src/components/SeedingRateCard/index.js
+++ b/src/components/SeedingRateCard/index.js
@@ -291,8 +291,8 @@ const SeedingRateCard = ({
     <>
       <Typography display="flex" alignItems="center" justifyContent="center">
         {seedingRateLabel}
-
       </Typography>
+      {/* TODO: use custom components for these chips */}
       <Box
         sx={{
           width: '110px',

--- a/src/components/SeedingRateCard/index.js
+++ b/src/components/SeedingRateCard/index.js
@@ -60,7 +60,6 @@ const SeedInfo = ({
     seedValue: seedData[seed.label].adjustedSeed,
   });
   const { unit } = useSelector((state) => state.calculator);
-
   // eslint-disable-next-line no-nested-ternary
   const unitText = unit === 'acre' ? 'Acre' : unit === 'sqft' ? 'SqFt' : '';
 
@@ -90,8 +89,8 @@ const SeedInfo = ({
         seedValue: seedData[seed.label].adjustedSeed,
       });
     }
-    setSingleSpeciesRate(calculatorResult[seed.label].step1.percentOfRate * 100);
-    setSurvival(calculatorResult[seed.label].step3.percentSurvival * 100);
+    setSingleSpeciesRate(Math.round(calculatorResult[seed.label].step1.percentOfRate * 100));
+    setSurvival(Math.round(twoDigit(calculatorResult[seed.label].step3.percentSurvival) * 100));
   }, [seedData, calculatorResult, unit]);
 
   return (
@@ -136,7 +135,7 @@ const SeedInfo = ({
           <Grid item xs={4}>
             <SeedLabel
               label="Default Single Species Seeding Rate PLS"
-              unit={unit === 'sqft' ? '1000SqFts' : unitText}
+              unit={unit === 'sqft' ? '1000SqFt' : unitText}
             />
           </Grid>
           <Grid item xs={4}>
@@ -166,7 +165,7 @@ const SeedInfo = ({
           <Grid item xs={4}>
             <SeedLabel
               label="Seeding Rate in Mix"
-              unit={unit === 'sqft' ? '1000SqFts' : unitText}
+              unit={unit === 'sqft' ? '1000SqFt' : unitText}
             />
           </Grid>
           <Grid item xs={4}>
@@ -184,7 +183,9 @@ const SeedInfo = ({
         </Grid>
 
         <Grid item xs={12} pt="1rem">
-          <Typography textAlign="left">% of Single Species Rate</Typography>
+          <Typography textAlign="left">
+            {`% of Single Species Rate: ${singleSpeciesRate}%`}
+          </Typography>
           <Slider
             min={0}
             max={100}
@@ -195,7 +196,9 @@ const SeedInfo = ({
           />
         </Grid>
         <Grid item xs={12}>
-          <Typography textAlign="left">% Survival</Typography>
+          <Typography textAlign="left">
+            {`% Survival: ${survival}%`}
+          </Typography>
           <Slider
             min={0}
             max={100}
@@ -213,9 +216,8 @@ const SeedInfo = ({
 const SeedingRateChip = ({ value }) => (
   <Box
     sx={{
-      width: '110px',
-      height: '50px',
-      padding: '11px',
+      width: '100px',
+      padding: '0.5rem',
       margin: '0 auto',
       backgroundColor: '#E5E7D5',
       border: '#C7C7C7 solid 1px',
@@ -227,7 +229,7 @@ const SeedingRateChip = ({ value }) => (
 );
 
 const SeedLabel = ({ label, unit }) => (
-  <Typography lineHeight="1rem" fontSize="0.8rem">
+  <Typography lineHeight="1rem" fontSize="0.8rem" padding="0.5rem 0">
     {label}
     {' per '}
     <span style={{ fontWeight: 'bold' }}>{unit}</span>

--- a/src/components/SeedingRateCard/index.js
+++ b/src/components/SeedingRateCard/index.js
@@ -68,25 +68,25 @@ const SeedInfo = ({
       setSingleData((prev) => ({
         ...prev,
         seedingRate: roundToMillionth(calculatorResult[seed.label].step1.defaultSingleSpeciesSeedingRatePLS / 43560),
-        plantValue: twoDigit(seedData[seed.label].defaultPlant / 43560),
-        seedValue: twoDigit(seedData[seed.label].defaultSeed / 43560),
+        plantValue: Math.round(seedData[seed.label].defaultPlant / 43560),
+        seedValue: Math.round(seedData[seed.label].defaultSeed / 43560),
       }));
       setMixData({
         seedingRate: roundToMillionth(calculatorResult[seed.label].step1.seedingRate / 43560),
-        plantValue: twoDigit(seedData[seed.label].adjustedPlant / 43560),
-        seedValue: twoDigit(seedData[seed.label].adjustedSeed / 43560),
+        plantValue: Math.round(seedData[seed.label].adjustedPlant / 43560),
+        seedValue: Math.round(seedData[seed.label].adjustedSeed / 43560),
       });
     } else if (unit === 'acre') {
       setSingleData((prev) => ({
         ...prev,
         seedingRate: calculatorResult[seed.label].step1.defaultSingleSpeciesSeedingRatePLS,
-        plantValue: seedData[seed.label].defaultPlant,
-        seedValue: seedData[seed.label].defaultSeed,
+        plantValue: Math.round(seedData[seed.label].defaultPlant),
+        seedValue: Math.round(seedData[seed.label].defaultSeed),
       }));
       setMixData({
         seedingRate: calculatorResult[seed.label].step1.seedingRate,
-        plantValue: seedData[seed.label].adjustedPlant,
-        seedValue: seedData[seed.label].adjustedSeed,
+        plantValue: Math.round(seedData[seed.label].adjustedPlant),
+        seedValue: Math.round(seedData[seed.label].adjustedSeed),
       });
     }
     setSingleSpeciesRate(Math.round(calculatorResult[seed.label].step1.percentOfRate * 100));
@@ -224,7 +224,7 @@ const SeedingRateChip = ({ value }) => (
       borderRadius: '16px',
     }}
   >
-    <Typography>{value.toFixed(2)}</Typography>
+    <Typography>{value}</Typography>
   </Box>
 );
 

--- a/src/components/SeedingRateCard/index.js
+++ b/src/components/SeedingRateCard/index.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import {
-  Typography, Box, Button, Grid, Card, CardContent, CardMedia,
+  Typography, Box, Button, Grid, Card, CardContent, CardMedia, Slider,
 } from '@mui/material';
 import { useDispatch, useSelector } from 'react-redux';
 import { twoDigit } from '../../shared/utils/calculator';
@@ -45,8 +45,10 @@ const UnitSelection = () => {
 };
 
 const SeedInfo = ({
-  seed, seedData, calculatorResult,
+  seed, seedData, calculatorResult, handleFormValueChange,
 }) => {
+  const [singleSpeciesRate, setSingleSpeciesRate] = useState(0);
+  const [survival, setSurvival] = useState(0);
   const [singleData, setSingleData] = useState({
     seedingRate: calculatorResult[seed.label].step1.defaultSingleSpeciesSeedingRatePLS,
     plantValue: seedData[seed.label].defaultPlant,
@@ -67,12 +69,12 @@ const SeedInfo = ({
     if (unit === 'sqft') {
       setSingleData((prev) => ({
         ...prev,
-        seedingRate: roundToMillionth(calculatorResult[seed.label].step1.defaultSingleSpeciesSeedingRatePLS / 43560),
+        seedingRate: 1000 * roundToMillionth(calculatorResult[seed.label].step1.defaultSingleSpeciesSeedingRatePLS / 43560),
         plantValue: twoDigit(seedData[seed.label].defaultPlant / 43560),
         seedValue: twoDigit(seedData[seed.label].defaultSeed / 43560),
       }));
       setMixData({
-        seedingRate: roundToMillionth(calculatorResult[seed.label].step1.seedingRate / 43560),
+        seedingRate: 1000 * roundToMillionth(calculatorResult[seed.label].step1.seedingRate / 43560),
         plantValue: twoDigit(seedData[seed.label].adjustedPlant / 43560),
         seedValue: twoDigit(seedData[seed.label].adjustedSeed / 43560),
       });
@@ -89,11 +91,13 @@ const SeedInfo = ({
         seedValue: seedData[seed.label].adjustedSeed,
       });
     }
+    setSingleSpeciesRate(calculatorResult[seed.label].step1.percentOfRate * 100);
+    setSurvival(calculatorResult[seed.label].step3.percentSurvival * 100);
   }, [seedData, calculatorResult, unit]);
 
   return (
     <Grid container p="0 5%">
-      <Grid item xs={4}>
+      <Grid item xs={4} justifyContent="center" display="flex">
         <Card
           sx={{
             backgroundColor: 'transparent',
@@ -125,7 +129,7 @@ const SeedInfo = ({
             <SeedingRateChip
               label="Default Single Species Seeding Rate PLS"
               value={singleData.seedingRate}
-              unit={unit === 'acre' ? '1000Acres' : unitText}
+              unit={unit === 'sqft' ? '1000SqFts' : unitText}
             />
           </Grid>
           <Grid item xs={4}>
@@ -148,7 +152,7 @@ const SeedInfo = ({
             <SeedingRateChip
               label="Seeding Rate in Mix"
               value={mixData.seedingRate}
-              unit={unit === 'acre' ? '1000Acres' : unitText}
+              unit={unit === 'sqft' ? '1000SqFts' : unitText}
             />
           </Grid>
           <Grid item xs={4}>
@@ -168,11 +172,25 @@ const SeedInfo = ({
         </Grid>
         <Grid item xs={12}>
           <Typography textAlign="left">% of Single Species Rate</Typography>
-          {/* <Slider /> */}
+          <Slider
+            min={0}
+            max={100}
+            value={singleSpeciesRate}
+            valueLabelDisplay="auto"
+            onChange={(e) => setSingleSpeciesRate(e.target.value)}
+            onChangeCommitted={() => handleFormValueChange(seed, 'percentOfRate', parseFloat(singleSpeciesRate) / 100)}
+          />
         </Grid>
         <Grid item xs={12}>
           <Typography textAlign="left">% Survival</Typography>
-          {/* <Slider /> */}
+          <Slider
+            min={0}
+            max={100}
+            value={survival}
+            valueLabelDisplay="auto"
+            onChange={(e) => setSurvival(e.target.value)}
+            onChangeCommitted={() => handleFormValueChange(seed, 'percentSurvival', parseFloat(survival) / 100)}
+          />
         </Grid>
       </Grid>
     </Grid>
@@ -197,7 +215,8 @@ const SeedingRateChip = ({ label, value, unit }) => (
     <Box sx={{ height: '2rem' }}>
       <Typography lineHeight="1rem" fontSize="0.8rem">
         {label}
-        {` per ${unit}`}
+        {' per '}
+        <span style={{ fontWeight: 'bold' }}>{unit}</span>
       </Typography>
     </Box>
 

--- a/src/components/SeedingRateCard/index.js
+++ b/src/components/SeedingRateCard/index.js
@@ -307,9 +307,9 @@ const SeedingRateCard = ({
         <Typography>{displayValue.seedingRateValue}</Typography>
       </Box>
       <Typography>
-        Lbs /
+        Lbs per
         {' '}
-        <span style={{ fontWeight: 'bold' }}>{unitText}</span>
+        <span style={{ fontWeight: 'bold' }}>{unit === 'sqft' ? '1000SqFt' : unitText}</span>
       </Typography>
 
       <Box

--- a/src/components/SeedingRateCard/index.js
+++ b/src/components/SeedingRateCard/index.js
@@ -16,7 +16,7 @@ import { selectUnitRedux } from '../../features/calculatorSlice/actions';
 
 const roundToMillionth = (num) => {
   const million = 10 ** 6;
-  return Math.round(num * million) / million;
+  return (Math.round(num * million) / million) * 1000;
 };
 
 const UnitSelection = () => {
@@ -59,7 +59,6 @@ const SeedInfo = ({
     plantValue: seedData[seed.label].adjustedPlant,
     seedValue: seedData[seed.label].adjustedSeed,
   });
-
   const { unit } = useSelector((state) => state.calculator);
 
   // eslint-disable-next-line no-nested-ternary
@@ -69,12 +68,12 @@ const SeedInfo = ({
     if (unit === 'sqft') {
       setSingleData((prev) => ({
         ...prev,
-        seedingRate: 1000 * roundToMillionth(calculatorResult[seed.label].step1.defaultSingleSpeciesSeedingRatePLS / 43560),
+        seedingRate: roundToMillionth(calculatorResult[seed.label].step1.defaultSingleSpeciesSeedingRatePLS / 43560),
         plantValue: twoDigit(seedData[seed.label].defaultPlant / 43560),
         seedValue: twoDigit(seedData[seed.label].defaultSeed / 43560),
       }));
       setMixData({
-        seedingRate: 1000 * roundToMillionth(calculatorResult[seed.label].step1.seedingRate / 43560),
+        seedingRate: roundToMillionth(calculatorResult[seed.label].step1.seedingRate / 43560),
         plantValue: twoDigit(seedData[seed.label].adjustedPlant / 43560),
         seedValue: twoDigit(seedData[seed.label].adjustedSeed / 43560),
       });
@@ -97,7 +96,7 @@ const SeedInfo = ({
 
   return (
     <Grid container p="0 5%">
-      <Grid item xs={4} justifyContent="center" display="flex">
+      <Grid item xs={12} md={4} justifyContent="center" display="flex">
         <Card
           sx={{
             backgroundColor: 'transparent',
@@ -123,54 +122,68 @@ const SeedInfo = ({
           />
         </Card>
       </Grid>
-      <Grid item xs={8}>
+      <Grid item xs={12} md={8} pt="1rem">
         <Grid container>
           <Grid item xs={4}>
-            <SeedingRateChip
+            <SeedingRateChip value={singleData.seedingRate} />
+          </Grid>
+          <Grid item xs={4}>
+            <SeedingRateChip value={singleData.plantValue} />
+          </Grid>
+          <Grid item xs={4}>
+            <SeedingRateChip value={singleData.seedValue} />
+          </Grid>
+          <Grid item xs={4}>
+            <SeedLabel
               label="Default Single Species Seeding Rate PLS"
-              value={singleData.seedingRate}
               unit={unit === 'sqft' ? '1000SqFts' : unitText}
             />
           </Grid>
           <Grid item xs={4}>
-            <SeedingRateChip
+            <SeedLabel
               label="Approx Plants"
-              value={singleData.plantValue}
               unit={unitText}
             />
           </Grid>
           <Grid item xs={4}>
-            <SeedingRateChip
+            <SeedLabel
               label="Seeds"
-              value={singleData.seedValue}
               unit={unitText}
             />
           </Grid>
         </Grid>
+
         <Grid container>
           <Grid item xs={4}>
-            <SeedingRateChip
+            <SeedingRateChip value={mixData.seedingRate} />
+          </Grid>
+          <Grid item xs={4}>
+            <SeedingRateChip value={mixData.plantValue} />
+          </Grid>
+          <Grid item xs={4}>
+            <SeedingRateChip value={mixData.seedValue} />
+          </Grid>
+          <Grid item xs={4}>
+            <SeedLabel
               label="Seeding Rate in Mix"
-              value={mixData.seedingRate}
               unit={unit === 'sqft' ? '1000SqFts' : unitText}
             />
           </Grid>
           <Grid item xs={4}>
-            <SeedingRateChip
+            <SeedLabel
               label="Approx Plants"
-              value={mixData.plantValue}
               unit={unitText}
             />
           </Grid>
           <Grid item xs={4}>
-            <SeedingRateChip
+            <SeedLabel
               label="Seeds"
-              value={mixData.seedValue}
               unit={unitText}
             />
           </Grid>
         </Grid>
-        <Grid item xs={12}>
+
+        <Grid item xs={12} pt="1rem">
           <Typography textAlign="left">% of Single Species Rate</Typography>
           <Slider
             min={0}
@@ -197,30 +210,28 @@ const SeedInfo = ({
   );
 };
 
-const SeedingRateChip = ({ label, value, unit }) => (
-  <>
-    <Box
-      sx={{
-        width: '110px',
-        height: '50px',
-        padding: '11px',
-        margin: '0 auto',
-        backgroundColor: '#E5E7D5',
-        border: '#C7C7C7 solid 1px',
-        borderRadius: '16px',
-      }}
-    >
-      <Typography>{value}</Typography>
-    </Box>
-    <Box sx={{ height: '2rem' }}>
-      <Typography lineHeight="1rem" fontSize="0.8rem">
-        {label}
-        {' per '}
-        <span style={{ fontWeight: 'bold' }}>{unit}</span>
-      </Typography>
-    </Box>
+const SeedingRateChip = ({ value }) => (
+  <Box
+    sx={{
+      width: '110px',
+      height: '50px',
+      padding: '11px',
+      margin: '0 auto',
+      backgroundColor: '#E5E7D5',
+      border: '#C7C7C7 solid 1px',
+      borderRadius: '16px',
+    }}
+  >
+    <Typography>{value.toFixed(2)}</Typography>
+  </Box>
+);
 
-  </>
+const SeedLabel = ({ label, unit }) => (
+  <Typography lineHeight="1rem" fontSize="0.8rem">
+    {label}
+    {' per '}
+    <span style={{ fontWeight: 'bold' }}>{unit}</span>
+  </Typography>
 );
 
 const SeedingRateCard = ({

--- a/src/components/SeedingRateCard/index.js
+++ b/src/components/SeedingRateCard/index.js
@@ -16,7 +16,7 @@ import { selectUnitRedux } from '../../features/calculatorSlice/actions';
 
 const roundToMillionth = (num) => {
   const million = 10 ** 6;
-  return (Math.round(num * million) / million) * 1000;
+  return Math.round(num * million) / (million / 1000);
 };
 
 const UnitSelection = () => {

--- a/src/pages/Calculator/Steps/CompletedPage/index.js
+++ b/src/pages/Calculator/Steps/CompletedPage/index.js
@@ -9,7 +9,6 @@ const CompletedPage = () => {
   const matchesUpMd = useMediaQuery(theme.breakpoints.up('md'));
   return (
     <>
-      {/* FIXME: is these words still needed? */}
       <Grid container>
         <Grid xs={12} item sx={{ pt: '50px' }} justifyContent="center">
           <Typography>

--- a/src/pages/Calculator/Steps/MixRatios/form.js
+++ b/src/pages/Calculator/Steps/MixRatios/form.js
@@ -133,9 +133,6 @@ const MixRatioSteps = ({
             <Grid item xs={3}>
               <NumberTextField
                 label={matchesMd ? '' : '% of Single Species Rate'}
-                // handleChange={(e) => {
-                //   handleFormValueChange(seed, 'percentOfRate', parseFloat(e.target.value) / 100);
-                // }}
                 disabled
                 value={convertToPercent(step1.percentOfRate)}
               />
@@ -267,9 +264,6 @@ const MixRatioSteps = ({
             <Grid item xs={3}>
               <NumberTextField
                 label={matchesMd ? '' : '% Survival'}
-                // handleChange={(e) => {
-                //   handleFormValueChange(seed, 'percentSurvival', parseFloat(e.target.value) / 100);
-                // }}
                 disabled
                 value={convertToPercent(step3.percentSurvival)}
               />

--- a/src/pages/Calculator/Steps/MixRatios/form.js
+++ b/src/pages/Calculator/Steps/MixRatios/form.js
@@ -135,9 +135,10 @@ const MixRatioSteps = ({
             <Grid item xs={3}>
               <NumberTextField
                 label={matchesMd ? '' : '% of Single Species Rate'}
-                handleChange={(e) => {
-                  handleFormValueChange(seed, 'percentOfRate', parseFloat(e.target.value) / 100);
-                }}
+                // handleChange={(e) => {
+                //   handleFormValueChange(seed, 'percentOfRate', parseFloat(e.target.value) / 100);
+                // }}
+                disabled
                 value={convertToPercent(step1.percentOfRate)}
               />
             </Grid>
@@ -268,9 +269,10 @@ const MixRatioSteps = ({
             <Grid item xs={3}>
               <NumberTextField
                 label={matchesMd ? '' : '% Survival'}
-                handleChange={(e) => {
-                  handleFormValueChange(seed, 'percentSurvival', parseFloat(e.target.value) / 100);
-                }}
+                // handleChange={(e) => {
+                //   handleFormValueChange(seed, 'percentSurvival', parseFloat(e.target.value) / 100);
+                // }}
+                disabled
                 value={convertToPercent(step3.percentSurvival)}
               />
             </Grid>

--- a/src/pages/Calculator/Steps/MixRatios/form.js
+++ b/src/pages/Calculator/Steps/MixRatios/form.js
@@ -88,12 +88,13 @@ const MixRatioSteps = ({
             </Grid>
           </Grid>
 
-          <Grid container p="1rem 1rem 0 1rem">
-            <Grid item xs={4}>
+          <Grid container p="1rem 0 0 0" justifyContent="space-evenly">
+            <Grid item xs={3}>
               <Typography variant="mathIcon">=</Typography>
             </Grid>
+            <Grid item xs={1} />
 
-            <Grid item xs={7}>
+            <Grid item xs={3}>
               <NumberTextField
                 label="Seeding Rate In Mix (Lbs per Acre)"
                 disabled
@@ -102,6 +103,7 @@ const MixRatioSteps = ({
             </Grid>
 
             <Grid item xs={1} />
+            <Grid item xs={3} />
           </Grid>
         </>
       )}

--- a/src/pages/Calculator/Steps/MixRatios/form.js
+++ b/src/pages/Calculator/Steps/MixRatios/form.js
@@ -88,7 +88,7 @@ const MixRatioSteps = ({
             </Grid>
           </Grid>
 
-          <Grid container p="10px">
+          <Grid container p="1rem 1rem 0 1rem">
             <Grid item xs={4}>
               <Typography variant="mathIcon">=</Typography>
             </Grid>

--- a/src/pages/Calculator/Steps/MixRatios/form.js
+++ b/src/pages/Calculator/Steps/MixRatios/form.js
@@ -7,7 +7,7 @@ import { convertToPercent } from '../../../../shared/utils/calculator';
 import '../steps.scss';
 
 const MixRatioSteps = ({
-  seed, council, handleFormValueChange, calculatorResult,
+  council, calculatorResult,
 }) => {
   const theme = useTheme();
   const matchesMd = useMediaQuery(theme.breakpoints.down('md'));
@@ -58,9 +58,7 @@ const MixRatioSteps = ({
             <Grid item xs={3}>
               <NumberTextField
                 label={matchesMd ? '' : 'Single Species Seeding Rate PLS (Lbs / Acre)'}
-                handleChange={(e) => {
-                  handleFormValueChange(seed, 'singleSpeciesSeedingRate', parseFloat(e.target.value));
-                }}
+                disabled
                 value={step1.defaultSingleSpeciesSeedingRatePLS}
               />
             </Grid>

--- a/src/pages/Calculator/Steps/MixRatios/index.js
+++ b/src/pages/Calculator/Steps/MixRatios/index.js
@@ -1,4 +1,6 @@
+/* eslint-disable react/no-unstable-nested-components */
 /* eslint-disable no-multi-str */
+
 /// ///////////////////////////////////////////////////////
 //                     Imports                          //
 /// ///////////////////////////////////////////////////////
@@ -13,7 +15,7 @@ import AccordionDetails from '@mui/material/AccordionDetails';
 import InfoIcon from '@mui/icons-material/Info';
 import MixRatioSteps from './form';
 import DSTPieChart from '../../../../components/DSTPieChart';
-import SeedingRateCard, { UnitSelection } from '../../../../components/SeedingRateCard';
+import SeedingRateCard, { UnitSelection, SeedInfo } from '../../../../components/SeedingRateCard';
 import {
   adjustProportions, adjustProportionsNECCC, createCalculator, createUserInput, calculatePieChartData,
   calculatePlantsandSeedsPerAcre,
@@ -206,6 +208,10 @@ const MixRatio = ({ calculator, setCalculator }) => {
         />
         )}
       </Grid>
+
+      {seedsSelected.map((seed) => (
+        <SeedInfo seed={seed} seedData={seedData} calculatorResult={calculatorResult} />
+      ))}
 
       {seedsSelected.map((seed, i) => (
         <Grid item xs={12} key={i}>

--- a/src/pages/Calculator/Steps/MixRatios/index.js
+++ b/src/pages/Calculator/Steps/MixRatios/index.js
@@ -179,9 +179,7 @@ const MixRatio = ({ calculator, setCalculator }) => {
 
       <Grid container display="flex" justifyContent="center">
         <Grid item style={{ position: 'fixed', top: '0px', zIndex: 1000 }}>
-
           {showAlert && (
-
           <FadeAlert
             showAlert={showAlert}
             severity="success"
@@ -201,7 +199,6 @@ const MixRatio = ({ calculator, setCalculator }) => {
             Adjust via the dropdown below as needed based on your goals.'}
           />
           )}
-
         </Grid>
       </Grid>
       <Grid item xs={6} sx={{ textAlign: 'justify' }}>
@@ -250,6 +247,7 @@ const MixRatio = ({ calculator, setCalculator }) => {
                   seedData={seedData}
                   calculatorResult={calculatorResult}
                   handleFormValueChange={handleFormValueChange}
+                  council={council}
                 />
 
                 <Grid item xs={12}>
@@ -270,9 +268,7 @@ const MixRatio = ({ calculator, setCalculator }) => {
                 <Grid item xs={12}>
                   {showSteps[seed.label] && (
                   <MixRatioSteps
-                    seed={seed}
                     council={council}
-                    handleFormValueChange={handleFormValueChange}
                     calculatorResult={calculatorResult[seed.label]}
                   />
                   )}

--- a/src/pages/Calculator/Steps/MixRatios/index.js
+++ b/src/pages/Calculator/Steps/MixRatios/index.js
@@ -7,12 +7,14 @@
 
 import React, { useState, useEffect } from 'react';
 import Grid from '@mui/material/Grid';
-import { Typography, Button, Alert } from '@mui/material';
+import { Typography, Button } from '@mui/material';
 import { useSelector, useDispatch } from 'react-redux';
 import Accordion from '@mui/material/Accordion';
 import AccordionSummary from '@mui/material/AccordionSummary';
 import AccordionDetails from '@mui/material/AccordionDetails';
-import InfoIcon from '@mui/icons-material/Info';
+import CloseIcon from '@mui/icons-material/Close';
+import IconButton from '@mui/material/IconButton';
+import { FadeAlert } from '@psa/dst.ui.fade-alert';
 import MixRatioSteps from './form';
 import DSTPieChart from '../../../../components/DSTPieChart';
 import { UnitSelection, SeedInfo } from '../../../../components/SeedingRateCard';
@@ -175,18 +177,33 @@ const MixRatio = ({ calculator, setCalculator }) => {
         <Typography variant="h2">Review Proportions</Typography>
       </Grid>
 
-      <Grid item xs={12}>
-        {showAlert && (
-        <Alert severity="success" onClose={() => setShowAlert(false)} icon={<InfoIcon />}>
-          {updatedForm ? 'You now have a custom mix.'
-            : 'This is a starting mix based on averages, but not a recommendation. \
+      <Grid container display="flex" justifyContent="center">
+        <Grid item style={{ position: 'fixed', top: '0px', zIndex: 1000 }}>
+
+          {showAlert && (
+
+          <FadeAlert
+            showAlert={showAlert}
+            severity="success"
+            action={(
+              <IconButton
+                aria-label="close"
+                color="inherit"
+                size="small"
+                onClick={() => setShowAlert(false)}
+              >
+                <CloseIcon fontSize="inherit" />
+
+              </IconButton>
+            )}
+            message={updatedForm ? 'You now have a custom mix.'
+              : 'This is a starting mix based on averages, but not a recommendation. \
             Adjust via the dropdown below as needed based on your goals.'}
+          />
+          )}
 
-        </Alert>
-        )}
-
+        </Grid>
       </Grid>
-
       <Grid item xs={6} sx={{ textAlign: 'justify' }}>
         <DSTPieChart
           chartData={piechartData.seedingRateArray}
@@ -228,25 +245,6 @@ const MixRatio = ({ calculator, setCalculator }) => {
 
             <AccordionDetails>
               <Grid container>
-
-                {/* <Grid item xs={6}>
-                  <SeedingRateCard
-                    seedingRateLabel="Default Single Species Seeding Rate PLS"
-                    seedingRateValue={calculatorResult[seed.label].step1.defaultSingleSpeciesSeedingRatePLS}
-                    plantValue={seedData[seed.label].defaultPlant}
-                    seedValue={seedData[seed.label].defaultSeed}
-                  />
-                </Grid>
-
-                <Grid item xs={6}>
-                  <SeedingRateCard
-                    seedingRateLabel="Seeding Rate in Mix"
-                    seedingRateValue={calculatorResult[seed.label].step1.seedingRate}
-                    plantValue={seedData[seed.label].adjustedPlant}
-                    seedValue={seedData[seed.label].adjustedSeed}
-                    showTooltip="mixSeedingRate"
-                  />
-                </Grid> */}
                 <SeedInfo
                   seed={seed}
                   seedData={seedData}

--- a/src/pages/Calculator/Steps/MixRatios/index.js
+++ b/src/pages/Calculator/Steps/MixRatios/index.js
@@ -15,7 +15,7 @@ import AccordionDetails from '@mui/material/AccordionDetails';
 import InfoIcon from '@mui/icons-material/Info';
 import MixRatioSteps from './form';
 import DSTPieChart from '../../../../components/DSTPieChart';
-import SeedingRateCard, { UnitSelection, SeedInfo } from '../../../../components/SeedingRateCard';
+import { UnitSelection, SeedInfo } from '../../../../components/SeedingRateCard';
 import {
   adjustProportions, adjustProportionsNECCC, createCalculator, createUserInput, calculatePieChartData,
   calculatePlantsandSeedsPerAcre,
@@ -209,10 +209,6 @@ const MixRatio = ({ calculator, setCalculator }) => {
         )}
       </Grid>
 
-      {seedsSelected.map((seed) => (
-        <SeedInfo seed={seed} seedData={seedData} calculatorResult={calculatorResult} />
-      ))}
-
       {seedsSelected.map((seed, i) => (
         <Grid item xs={12} key={i}>
           <Accordion
@@ -233,7 +229,7 @@ const MixRatio = ({ calculator, setCalculator }) => {
             <AccordionDetails>
               <Grid container>
 
-                <Grid item xs={6}>
+                {/* <Grid item xs={6}>
                   <SeedingRateCard
                     seedingRateLabel="Default Single Species Seeding Rate PLS"
                     seedingRateValue={calculatorResult[seed.label].step1.defaultSingleSpeciesSeedingRatePLS}
@@ -250,7 +246,14 @@ const MixRatio = ({ calculator, setCalculator }) => {
                     seedValue={seedData[seed.label].adjustedSeed}
                     showTooltip="mixSeedingRate"
                   />
-                </Grid>
+                </Grid> */}
+                <SeedInfo
+                  seed={seed}
+                  seedData={seedData}
+                  calculatorResult={calculatorResult}
+                  handleFormValueChange={handleFormValueChange}
+                />
+
                 <Grid item xs={12}>
                   <UnitSelection />
                 </Grid>

--- a/src/pages/Calculator/Steps/ReviewMix/Steps.js
+++ b/src/pages/Calculator/Steps/ReviewMix/Steps.js
@@ -348,7 +348,6 @@ const ReviewMixSteps = ({
             />
           </Grid>
 
-          {/* <Grid item xs={1} /> */}
         </Grid>
       </>
 

--- a/src/pages/Calculator/Steps/ReviewMix/Steps.js
+++ b/src/pages/Calculator/Steps/ReviewMix/Steps.js
@@ -117,7 +117,7 @@ const ReviewMixSteps = ({
               />
             </Grid>
           </Grid>
-          <Grid container p="10px">
+          <Grid container p="1rem 1rem 0 1rem">
             <Grid item xs={4}>
               <Typography variant="mathIcon">=</Typography>
             </Grid>

--- a/src/pages/Calculator/Steps/ReviewMix/Steps.js
+++ b/src/pages/Calculator/Steps/ReviewMix/Steps.js
@@ -89,11 +89,12 @@ const ReviewMixSteps = ({
     return (
       <Grid container>
         <Grid item xs={2} md={3} />
-        <Grid item xs={10} md={9}>
-          <Typography textAlign="justify">
+        <Grid item xs={8} md={6}>
+          <Typography>
             {`${label}: ${value} ${unit}`}
           </Typography>
         </Grid>
+        <Grid item xs={2} md={3} />
         <Grid item xs={2} md={3} />
         <Grid item xs={8} md={6}>
           <Slider
@@ -174,20 +175,20 @@ const ReviewMixSteps = ({
               />
             </Grid>
           </Grid>
-          <Grid container p="1rem 1rem 0 1rem">
-            <Grid item xs={4}>
+          <Grid container p="1rem 0 0 0" justifyContent="space-evenly">
+            <Grid item xs={3}>
               <Typography variant="mathIcon">=</Typography>
             </Grid>
-
-            <Grid item xs={7}>
+            <Grid item xs={1} />
+            <Grid item xs={3}>
               <NumberTextField
                 label="Seeding Rate In Mix (Lbs per Acre)"
                 disabled
                 value={step1.seedingRate}
               />
             </Grid>
-
             <Grid item xs={1} />
+            <Grid item xs={3} />
           </Grid>
         </>
       )}
@@ -427,18 +428,21 @@ const ReviewMixSteps = ({
             />
           </Grid>
         </Grid>
-        <Grid container p="1rem 1rem 0 1rem">
-          <Grid item xs={4}>
+        <Grid container p="1rem 0 0 0" justifyContent="space-evenly">
+          <Grid item xs={3}>
             <Typography variant="mathIcon">=</Typography>
           </Grid>
+          <Grid item xs={1} />
 
-          <Grid item xs={8}>
+          <Grid item xs={3}>
             <NumberTextField
               label="Bulk Seeding Rate (Lbs per Acre)"
               disabled
               value={step4.bulkSeedingRate}
             />
           </Grid>
+          <Grid item xs={1} />
+          <Grid item xs={3} />
 
         </Grid>
       </>

--- a/src/pages/Calculator/Steps/ReviewMix/Steps.js
+++ b/src/pages/Calculator/Steps/ReviewMix/Steps.js
@@ -142,9 +142,10 @@ const ReviewMixSteps = ({
             <Grid item xs={3}>
               <NumberTextField
                 label={matchesMd ? '' : 'Single Species Seeding Rate PLS (Lbs per Acre)'}
-                handleChange={(e) => {
-                  handleFormValueChange(seed, 'singleSpeciesSeedingRate', parseFloat(e.target.value));
-                }}
+                disabled
+                // handleChange={(e) => {
+                //   handleFormValueChange(seed, 'singleSpeciesSeedingRate', parseFloat(e.target.value));
+                // }}
                 value={step1.singleSpeciesSeedingRate}
               />
             </Grid>
@@ -230,9 +231,10 @@ const ReviewMixSteps = ({
             <Grid item xs={3}>
               <NumberTextField
                 label={matchesMd ? '' : '% of Single Species Rate'}
-                handleChange={(e) => {
-                  handleFormValueChange(seed, 'percentOfRate', parseFloat(e.target.value) / 100);
-                }}
+                disabled
+                // handleChange={(e) => {
+                //   handleFormValueChange(seed, 'percentOfRate', parseFloat(e.target.value) / 100);
+                // }}
                 value={convertToPercent(step1.percentOfRate)}
               />
             </Grid>
@@ -402,9 +404,10 @@ const ReviewMixSteps = ({
           <Grid item xs={3}>
             <NumberTextField
               label={matchesMd ? '' : '% Germination'}
-              handleChange={(e) => {
-                handleFormValueChange(seed, 'germination', parseFloat(e.target.value) / 100);
-              }}
+              disabled
+              // handleChange={(e) => {
+              //   handleFormValueChange(seed, 'germination', parseFloat(e.target.value) / 100);
+              // }}
               value={convertToPercent(step4.germination)}
             />
           </Grid>
@@ -416,9 +419,10 @@ const ReviewMixSteps = ({
           <Grid item xs={3}>
             <NumberTextField
               label={matchesMd ? '' : '% Purity'}
-              handleChange={(e) => {
-                handleFormValueChange(seed, 'purity', parseFloat(e.target.value) / 100);
-              }}
+              disabled
+              // handleChange={(e) => {
+              //   handleFormValueChange(seed, 'purity', parseFloat(e.target.value) / 100);
+              // }}
               value={convertToPercent(step4.purity)}
             />
           </Grid>

--- a/src/pages/Calculator/Steps/ReviewMix/Steps.js
+++ b/src/pages/Calculator/Steps/ReviewMix/Steps.js
@@ -190,7 +190,7 @@ const ReviewMixSteps = ({
         <Grid item xs={12}>
           <Typography variant="stepHeader">Adjustment from Seeding Method</Typography>
         </Grid>
-        <Grid item xs={6} margin="1rem">
+        <Grid item xs={6} paddingLeft="1rem" paddingBottom="1rem">
           <Dropdown
             value={options[seed.label].plantingMethod ?? ''}
             label="Seeding Method: "
@@ -335,12 +335,12 @@ const ReviewMixSteps = ({
             />
           </Grid>
         </Grid>
-        <Grid container p="10px">
+        <Grid container p="1rem 1rem 0 1rem">
           <Grid item xs={4}>
             <Typography variant="mathIcon">=</Typography>
           </Grid>
 
-          <Grid item xs={7}>
+          <Grid item xs={8}>
             <NumberTextField
               label="Bulk Seeding Rate (Lbs / Acre)"
               disabled
@@ -348,7 +348,7 @@ const ReviewMixSteps = ({
             />
           </Grid>
 
-          <Grid item xs={1} />
+          {/* <Grid item xs={1} /> */}
         </Grid>
       </>
 

--- a/src/pages/Calculator/Steps/SeedTagInfo/index.js
+++ b/src/pages/Calculator/Steps/SeedTagInfo/index.js
@@ -163,9 +163,10 @@ const SeedTagInfo = ({ completedStep, setCompletedStep }) => {
                   </LeftGrid>
                   <Grid item xs={4}>
                     <NumberTextField
-                      value={seedsPerPound(seed)}
+                      value={parseFloat(seedsPerPound(seed))}
                       handleChange={(e) => {
-                        updateSeedsPerPound(seed.label, parseFloat(e.target.value));
+                        const val = parseFloat(e.target.value.replace(/,/g, ''));
+                        updateSeedsPerPound(seed.label, val);
                       }}
                     />
                   </Grid>

--- a/src/pages/Calculator/Steps/SiteCondition/form.js
+++ b/src/pages/Calculator/Steps/SiteCondition/form.js
@@ -68,9 +68,10 @@ const SiteConditionForm = ({
   const dispatch = useDispatch();
   const {
     state, soilDrainage, tileDrainage, county, plannedPlantingDate,
-    acres, soilFertility, checkNRCSStandards,
+    soilFertility, checkNRCSStandards,
   } = useSelector((s) => s.siteCondition);
 
+  const [acres, setAcres] = useState(0);
   const [soilDrainagePrev, setSoilDrainagePrev] = useState(soilDrainage);
 
   const handleSoilDrainage = (e) => {
@@ -243,7 +244,11 @@ const SiteConditionForm = ({
           label="Acres"
           disabled={false}
           handleChange={(e) => {
-            dispatch(setAcresRedux(parseFloat(e.target.value)));
+            // FIXME: this is a temporary fix for number textboxes, need to further investigate solutions.
+            // maybe use error property: https://mui.com/material-ui/react-text-field/#validation
+            // Same situation applies to Seed Tag Info too.
+            setAcres(e.target.value);
+            if (!Number.isNaN(parseFloat(e.target.value))) dispatch(setAcresRedux(parseFloat(e.target.value)));
           }}
           placeholder="Enter your field acres here"
         />

--- a/src/shared/themes/index.js
+++ b/src/shared/themes/index.js
@@ -41,12 +41,12 @@ const dstTheme = createTheme({
     stepHeader: {
       fontFamily: '"Roboto","Helvetica","Arial",sans-serif',
       lineHeight: '1.5',
-      padding: '1rem',
+      padding: '0 1rem',
       background: '#e5e7d5',
-      margin: '1rem 0px',
-      fontSize: '18px',
+      margin: '1rem 0',
+      fontSize: '1rem',
       fontWeight: 600,
-      textAlign: 'justify',
+      // textAlign: 'justify',
     },
   },
   components: {

--- a/src/shared/themes/index.js
+++ b/src/shared/themes/index.js
@@ -46,7 +46,6 @@ const dstTheme = createTheme({
       margin: '1rem 0',
       fontSize: '1rem',
       fontWeight: 600,
-      // textAlign: 'justify',
     },
   },
   components: {


### PR DESCRIPTION
- Updated Mix Ratio with scroller design for MCCC and NECCC.
- Updated numbers to formatted local strings across the app.
- Change seeding rate unit from lbs per sqft to lbs per 1000 sqft.
- Updated step captions.
- Disabled calculations in Mix Ratios.
- Updated disclaimer with bit Alert component.
- Added scrollers for textboxes in Review Mix, disabled textboxes.
- Resolved bug for updating seeding method in Review Mix.