### PR TITLE
Fix survival rate parsing problem

### DIFF
--- a/src/pages/Calculator/Steps/SpeciesSelection/PlantList.js
+++ b/src/pages/Calculator/Steps/SpeciesSelection/PlantList.js
@@ -105,7 +105,7 @@ const PlantList = ({
       dispatch(addSeedRedux(data));
       const { label, attributes } = data;
       const percentSurvival = council === 'MCCC'
-        ? parseFloat(attributes.Coefficients['% Chance of Winter Survial'].values[0])
+        ? parseFloat(attributes.Coefficients['% Live Seed to Emergence'].values[0])
         : '';
       // set initial options
       dispatch(setOptionRedux(label, {


### PR DESCRIPTION
- Fixed survival problem in Mix Ratios, the problem is because the survival rate was parsing wrongly from the api.