### PR TITLE
Design changes - seed tag info

### DIFF
--- a/src/components/NumberTextField/index.js
+++ b/src/components/NumberTextField/index.js
@@ -8,6 +8,7 @@ const NumberTextField = ({
   disabled,
   emptyWarning,
   placeholder,
+  sx,
 }) => {
   const [displayValue, setDisplayValue] = useState(value);
   const [error, setError] = useState(false);
@@ -71,6 +72,7 @@ const NumberTextField = ({
         '.MuiOutlinedInput-notchedOutline': emptyWarning && {
           borderColor: 'rgba(255, 0, 0, .5)',
         },
+        ...sx,
       }}
       error={error}
       helperText={helperText}

--- a/src/components/NumberTextField/index.js
+++ b/src/components/NumberTextField/index.js
@@ -9,6 +9,7 @@ const NumberTextField = ({
   emptyWarning,
   placeholder,
   sx,
+  className,
 }) => {
   const [displayValue, setDisplayValue] = useState(value);
   const [error, setError] = useState(false);
@@ -59,6 +60,7 @@ const NumberTextField = ({
       value={displayValue}
       label={label}
       onChange={handleChange}
+      className={className}
       InputLabelProps={{
         shrink: true,
       }}

--- a/src/pages/Calculator/Steps/SeedTagInfo/index.js
+++ b/src/pages/Calculator/Steps/SeedTagInfo/index.js
@@ -21,7 +21,10 @@ import { validateForms } from '../../../../shared/utils/format';
 const LeftGrid = styled(Grid)({
   '&.MuiGrid-item': {
     height: '80px',
-    paddingTop: '15px',
+    paddingTop: '8px',
+    paddingLeft: '15px',
+    paddingRight: '20px',
+    // maxWidth: 'fit-content',
     '& p': {
       fontWeight: 'bold',
     },
@@ -153,46 +156,79 @@ const SeedTagInfo = ({
                 <Typography>{seed.label}</Typography>
               </AccordionSummary>
               <AccordionDetails>
-                <Grid container>
-
-                  <LeftGrid item xs={6}>
+                <Grid
+                  container
+                  sx={{ justifyContent: 'flex-start' }}
+                >
+                  <LeftGrid item xs={4}>
                     <Typography>% Germination: </Typography>
                   </LeftGrid>
-                  <Grid item xs={4}>
+                  <Grid item xs={2}>
                     <NumberTextField
                       value={(options[seed.label].germination ?? 0.85) * 100}
                       onChange={(val) => {
                         updateGermination(seed.label, val / 100);
                       }}
+                      sx={{
+                        '& .MuiOutlinedInput-root': {
+                          borderRadius: '0px',
+                          backgroundColor: 'white',
+                        },
+                        '& .MuiInputBase-input': {
+                          fontSize: 16,
+                          width: 'auto',
+                          padding: '10px 10px',
+                        },
+                      }}
                     />
                   </Grid>
-                  <Grid item xs={2} />
-
-                  <LeftGrid item xs={6}>
+                  <Grid item xs={6} />
+                  <LeftGrid item xs={4}>
                     <Typography>% Purity: </Typography>
                   </LeftGrid>
-                  <Grid item xs={4}>
+                  <Grid item xs={2}>
                     <NumberTextField
                       value={(options[seed.label].purity ?? 0.9) * 100}
                       onChange={(val) => {
                         updatePurity(seed.label, val / 100);
                       }}
+                      sx={{
+                        '& .MuiOutlinedInput-root': {
+                          borderRadius: '0px',
+                          backgroundColor: 'white',
+                        },
+                        '& .MuiInputBase-input': {
+                          fontSize: 16,
+                          width: 'auto',
+                          padding: '10px 10px',
+                        },
+                      }}
                     />
                   </Grid>
-                  <Grid item xs={2} />
-
-                  <LeftGrid item xs={6}>
+                  <Grid item xs={6} />
+                  <LeftGrid item xs={4}>
                     <Typography>Seeds per Pound </Typography>
                   </LeftGrid>
-                  <Grid item xs={4}>
+                  <Grid item xs={2}>
                     <NumberTextField
                       value={parseFloat(seedsPerPound(seed))}
                       onChange={(val) => {
                         updateSeedsPerPound(seed.label, val);
                       }}
+                      sx={{
+                        '& .MuiOutlinedInput-root': {
+                          borderRadius: '0px',
+                          backgroundColor: 'white',
+                        },
+                        '& .MuiInputBase-input': {
+                          fontSize: 16,
+                          width: 'auto',
+                          padding: '10px 10px',
+                        },
+                      }}
                     />
                   </Grid>
-                  <Grid item xs={2} />
+                  <Grid item xs={6} />
                 </Grid>
 
               </AccordionDetails>

--- a/src/pages/Calculator/Steps/SeedTagInfo/index.js
+++ b/src/pages/Calculator/Steps/SeedTagInfo/index.js
@@ -24,10 +24,21 @@ const LeftGrid = styled(Grid)({
     paddingTop: '8px',
     paddingLeft: '15px',
     paddingRight: '20px',
-    // maxWidth: 'fit-content',
     '& p': {
       fontWeight: 'bold',
     },
+  },
+});
+
+const SeedTagNumField = styled(NumberTextField)({
+  '& .MuiOutlinedInput-root': {
+    borderRadius: '0px',
+    backgroundColor: 'white',
+  },
+  '& .MuiInputBase-input': {
+    fontSize: 16,
+    width: 'auto',
+    padding: '10px 10px',
   },
 });
 
@@ -161,21 +172,10 @@ const SeedTagInfo = ({
                     <Typography>% Germination: </Typography>
                   </LeftGrid>
                   <Grid item xs={4} lg={1} xl={1}>
-                    <NumberTextField
+                    <SeedTagNumField
                       value={(options[seed.label].germination ?? 0.85) * 100}
                       onChange={(val) => {
                         updateGermination(seed.label, val / 100);
-                      }}
-                      sx={{
-                        '& .MuiOutlinedInput-root': {
-                          borderRadius: '0px',
-                          backgroundColor: 'white',
-                        },
-                        '& .MuiInputBase-input': {
-                          fontSize: 16,
-                          width: 'auto',
-                          padding: '10px 10px',
-                        },
                       }}
                     />
                   </Grid>
@@ -185,21 +185,10 @@ const SeedTagInfo = ({
                     <Typography>% Purity: </Typography>
                   </LeftGrid>
                   <Grid item xs={4} lg={1} xl={1}>
-                    <NumberTextField
+                    <SeedTagNumField
                       value={(options[seed.label].purity ?? 0.9) * 100}
                       onChange={(val) => {
                         updatePurity(seed.label, val / 100);
-                      }}
-                      sx={{
-                        '& .MuiOutlinedInput-root': {
-                          borderRadius: '0px',
-                          backgroundColor: 'white',
-                        },
-                        '& .MuiInputBase-input': {
-                          fontSize: 16,
-                          width: 'auto',
-                          padding: '10px 10px',
-                        },
                       }}
                     />
                   </Grid>
@@ -209,21 +198,10 @@ const SeedTagInfo = ({
                     <Typography>Seeds per Pound </Typography>
                   </LeftGrid>
                   <Grid item xs={4} lg={1} xl={1}>
-                    <NumberTextField
+                    <SeedTagNumField
                       value={parseFloat(seedsPerPound(seed))}
                       onChange={(val) => {
                         updateSeedsPerPound(seed.label, val);
-                      }}
-                      sx={{
-                        '& .MuiOutlinedInput-root': {
-                          borderRadius: '0px',
-                          backgroundColor: 'white',
-                        },
-                        '& .MuiInputBase-input': {
-                          fontSize: 16,
-                          width: 'auto',
-                          padding: '10px 10px',
-                        },
                       }}
                     />
                   </Grid>

--- a/src/pages/Calculator/Steps/SeedTagInfo/index.js
+++ b/src/pages/Calculator/Steps/SeedTagInfo/index.js
@@ -156,14 +156,11 @@ const SeedTagInfo = ({
                 <Typography>{seed.label}</Typography>
               </AccordionSummary>
               <AccordionDetails>
-                <Grid
-                  container
-                  sx={{ justifyContent: 'flex-start' }}
-                >
-                  <LeftGrid item xs={4}>
+                <Grid container>
+                  <LeftGrid item xs={6} lg={2} xl={2}>
                     <Typography>% Germination: </Typography>
                   </LeftGrid>
-                  <Grid item xs={2}>
+                  <Grid item xs={4} lg={1} xl={1}>
                     <NumberTextField
                       value={(options[seed.label].germination ?? 0.85) * 100}
                       onChange={(val) => {
@@ -182,11 +179,12 @@ const SeedTagInfo = ({
                       }}
                     />
                   </Grid>
-                  <Grid item xs={6} />
-                  <LeftGrid item xs={4}>
+                  <Grid item xs={2} lg={1} xl={1} />
+
+                  <LeftGrid item xs={6} lg={2} xl={2}>
                     <Typography>% Purity: </Typography>
                   </LeftGrid>
-                  <Grid item xs={2}>
+                  <Grid item xs={4} lg={1} xl={1}>
                     <NumberTextField
                       value={(options[seed.label].purity ?? 0.9) * 100}
                       onChange={(val) => {
@@ -205,11 +203,12 @@ const SeedTagInfo = ({
                       }}
                     />
                   </Grid>
-                  <Grid item xs={6} />
-                  <LeftGrid item xs={4}>
+                  <Grid item xs={2} lg={1} xl={1} />
+
+                  <LeftGrid item xs={6} lg={2} xl={2}>
                     <Typography>Seeds per Pound </Typography>
                   </LeftGrid>
-                  <Grid item xs={2}>
+                  <Grid item xs={4} lg={1} xl={1}>
                     <NumberTextField
                       value={parseFloat(seedsPerPound(seed))}
                       onChange={(val) => {
@@ -228,7 +227,7 @@ const SeedTagInfo = ({
                       }}
                     />
                   </Grid>
-                  <Grid item xs={6} />
+                  <Grid item xs={2} lg={1} xl={1} />
                 </Grid>
 
               </AccordionDetails>

--- a/src/pages/Calculator/Steps/SeedTagInfo/index.js
+++ b/src/pages/Calculator/Steps/SeedTagInfo/index.js
@@ -20,10 +20,11 @@ import { validateForms } from '../../../../shared/utils/format';
 
 const LeftGrid = styled(Grid)({
   '&.MuiGrid-item': {
-    height: '80px',
+    height: '50px',
     paddingTop: '8px',
     paddingLeft: '15px',
     paddingRight: '20px',
+    textAlign: 'left',
     '& p': {
       fontWeight: 'bold',
     },
@@ -168,10 +169,10 @@ const SeedTagInfo = ({
               </AccordionSummary>
               <AccordionDetails>
                 <Grid container>
-                  <LeftGrid item xs={6} lg={2} xl={2}>
+                  <LeftGrid item xs={4} lg={2} xl={2}>
                     <Typography>% Germination: </Typography>
                   </LeftGrid>
-                  <Grid item xs={4} lg={1} xl={1}>
+                  <Grid item xs={2} lg={1} xl={1}>
                     <SeedTagNumField
                       value={(options[seed.label].germination ?? 0.85) * 100}
                       onChange={(val) => {
@@ -179,12 +180,12 @@ const SeedTagInfo = ({
                       }}
                     />
                   </Grid>
-                  <Grid item xs={2} lg={1} xl={1} />
+                  <Grid item xs={6} lg={1} xl={1} />
 
-                  <LeftGrid item xs={6} lg={2} xl={2}>
+                  <LeftGrid item xs={4} lg={2} xl={2}>
                     <Typography>% Purity: </Typography>
                   </LeftGrid>
-                  <Grid item xs={4} lg={1} xl={1}>
+                  <Grid item xs={2} lg={1} xl={1}>
                     <SeedTagNumField
                       value={(options[seed.label].purity ?? 0.9) * 100}
                       onChange={(val) => {
@@ -192,12 +193,12 @@ const SeedTagInfo = ({
                       }}
                     />
                   </Grid>
-                  <Grid item xs={2} lg={1} xl={1} />
+                  <Grid item xs={6} lg={1} xl={1} />
 
-                  <LeftGrid item xs={6} lg={2} xl={2}>
+                  <LeftGrid item xs={4} lg={2} xl={2}>
                     <Typography>Seeds per Pound </Typography>
                   </LeftGrid>
-                  <Grid item xs={4} lg={1} xl={1}>
+                  <Grid item xs={2} lg={1} xl={1}>
                     <SeedTagNumField
                       value={parseFloat(seedsPerPound(seed))}
                       onChange={(val) => {
@@ -205,7 +206,7 @@ const SeedTagInfo = ({
                       }}
                     />
                   </Grid>
-                  <Grid item xs={2} lg={1} xl={1} />
+                  <Grid item xs={6} lg={1} xl={1} />
                 </Grid>
 
               </AccordionDetails>


### PR DESCRIPTION
- [x] Left align the species titles
- [x] Reduce the width of the text boxes and titles
- [x] Move the text entry box to the left so its closer to the species titles
- [x] Reduce the height of the species titles and text entry boxes, but maintain the font size (there should be less padding between the box and the text) 
- [x] Make the corners on the text entry boxes less round
- [x] Make the background of the text entry box white
- [x] 3 items should be in line horizontal for xl, lg

<img src="https://github.com/precision-sustainable-ag/dst-seedcalc/assets/40169508/cea3faac-7a12-42b4-aa7e-0c8d5bc972de" height="400px" />
<img src="https://github.com/precision-sustainable-ag/dst-seedcalc/assets/40169508/0aece73c-e035-46e4-bba5-fc8a14c8c146" height="400px" />
<img src="https://github.com/precision-sustainable-ag/dst-seedcalc/assets/40169508/8cd02a0f-4bdf-4b8f-9dc4-13e02ebf7cd5" height="400px" />

