### PR TITLE
Update user history

### DIFF
--- a/src/components/DSTImport/index.js
+++ b/src/components/DSTImport/index.js
@@ -31,7 +31,7 @@ const DSTImport = ({ token }) => {
 
   const dispatch = useDispatch();
 
-  const { loadHistory } = useUserHistory(token);
+  const { loadHistory } = useUserHistory();
 
   const { calculationName } = useSelector((state) => state.user);
 
@@ -69,14 +69,14 @@ const DSTImport = ({ token }) => {
   };
 
   const handleLoadUserHistory = () => {
-    loadHistory(calculationName);
+    loadHistory(token, calculationName);
     setOpenModal(!openModal);
   };
 
   // initially load all history records
   useEffect(() => {
     const loadHistories = async () => {
-      const historyList = await loadHistory();
+      const historyList = await loadHistory(token);
       setHistories(historyList);
     };
     // token is null initially so only call when token is available

--- a/src/components/DSTImport/index.js
+++ b/src/components/DSTImport/index.js
@@ -73,11 +73,6 @@ const DSTImport = ({ token }) => {
     setOpenModal(!openModal);
   };
 
-  // open the modal if user is logged in
-  useEffect(() => {
-    if (isAuthenticated) setOpenModal(true);
-  }, []);
-
   // initially load all history records
   useEffect(() => {
     const loadHistories = async () => {

--- a/src/components/DSTImport/index.js
+++ b/src/components/DSTImport/index.js
@@ -9,8 +9,8 @@ import { importFromCSVCalculator } from '../../features/calculatorSlice/actions'
 import { setSiteConditionRedux } from '../../features/siteConditionSlice/actions';
 import useUserHistory from '../../shared/hooks/useUserHistory';
 import Dropdown from '../Dropdown';
-import { setCalculationNameRedux } from '../../features/userSlice/actions';
-import HistoryDialog, { historyDialogFromEnums } from '../HistoryDialog';
+import { setCalculationNameRedux, setHistoryDialogStateRedux } from '../../features/userSlice/actions';
+import HistoryDialog from '../HistoryDialog';
 
 const modalStyle = {
   position: 'absolute',
@@ -107,12 +107,13 @@ const DSTImport = ({ token }) => {
                   </Typography>
                 </Grid>
                 <Grid item xs={12} display="flex" justifyContent="center">
-                  <HistoryDialog
-                    buttonLabel="create new calculation"
-                    from={historyDialogFromEnums.siteCondition}
-                    token={token}
-                    setOpenModal={setOpenModal}
-                  />
+                  <HistoryDialog />
+                  <Button
+                    variant="contained"
+                    onClick={() => dispatch(setHistoryDialogStateRedux({ open: true, type: 'add' }))}
+                  >
+                    create new calculation
+                  </Button>
                 </Grid>
               </Grid>
 

--- a/src/components/DSTImport/index.js
+++ b/src/components/DSTImport/index.js
@@ -3,13 +3,13 @@ import Papa from 'papaparse';
 import {
   Box, Grid, Modal, Typography, Button,
 } from '@mui/material';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { useAuth0 } from '@auth0/auth0-react';
 import { importFromCSVCalculator } from '../../features/calculatorSlice/actions';
 import { setSiteConditionRedux } from '../../features/siteConditionSlice/actions';
 import useUserHistory from '../../shared/hooks/useUserHistory';
 import Dropdown from '../Dropdown';
-import { setCalculationNameRedux, setHistoryDialogStateRedux } from '../../features/userSlice/actions';
+import { setHistoryDialogStateRedux } from '../../features/userSlice/actions';
 
 const modalStyle = {
   position: 'absolute',
@@ -26,28 +26,18 @@ const modalStyle = {
 
 const DSTImport = ({ token }) => {
   const [openModal, setOpenModal] = useState(false);
-
   const [histories, setHistories] = useState([]);
+  const [calculationName, setCaclulationName] = useState('');
 
   const dispatch = useDispatch();
 
   const { loadHistory } = useUserHistory();
-
-  const { calculationName } = useSelector((state) => state.user);
 
   const { isAuthenticated } = useAuth0();
 
   /// ///////////////////////////////////////////////////////
   //                  Import Logic                        //
   /// ///////////////////////////////////////////////////////
-
-  const handleOpenModal = () => {
-    // there's possibilities that click 'Create New Calculation', set a name and then click 'Import'.
-    // If this happens then the dropdown will popup with a not available name.
-    // Set the calculation name to empty to prevent this behaviour.
-    dispatch(setCalculationNameRedux(''));
-    setOpenModal(true);
-  };
 
   const handleFileUpload = (event) => {
     Papa.parse(event.target.files[0], {
@@ -62,10 +52,6 @@ const DSTImport = ({ token }) => {
         setOpenModal(!openModal);
       },
     });
-  };
-
-  const handleSelectHistory = (e) => {
-    dispatch(setCalculationNameRedux(e.target.value));
   };
 
   const handleLoadUserHistory = () => {
@@ -152,7 +138,7 @@ const DSTImport = ({ token }) => {
                       value={calculationName}
                       label="Select your calculation"
                       items={histories}
-                      handleChange={handleSelectHistory}
+                      handleChange={(e) => setCaclulationName(e.target.value)}
                       minWidth={220}
                     />
                   </Grid>
@@ -169,7 +155,7 @@ const DSTImport = ({ token }) => {
       </Modal>
       <Button
         variant="contained"
-        onClick={handleOpenModal}
+        onClick={() => setOpenModal(true)}
         sx={{ textDecoration: 'none', margin: '1rem' }}
       >
         {isAuthenticated ? 'Import / Create calculation' : 'Import Calculation'}

--- a/src/components/DSTImport/index.js
+++ b/src/components/DSTImport/index.js
@@ -10,7 +10,6 @@ import { setSiteConditionRedux } from '../../features/siteConditionSlice/actions
 import useUserHistory from '../../shared/hooks/useUserHistory';
 import Dropdown from '../Dropdown';
 import { setCalculationNameRedux, setHistoryDialogStateRedux } from '../../features/userSlice/actions';
-import HistoryDialog from '../HistoryDialog';
 
 const modalStyle = {
   position: 'absolute',
@@ -107,10 +106,12 @@ const DSTImport = ({ token }) => {
                   </Typography>
                 </Grid>
                 <Grid item xs={12} display="flex" justifyContent="center">
-                  <HistoryDialog />
                   <Button
                     variant="contained"
-                    onClick={() => dispatch(setHistoryDialogStateRedux({ open: true, type: 'add' }))}
+                    onClick={() => {
+                      dispatch(setHistoryDialogStateRedux({ open: true, type: 'add' }));
+                      setOpenModal(false);
+                    }}
                   >
                     create new calculation
                   </Button>

--- a/src/components/HistoryDialog/index.js
+++ b/src/components/HistoryDialog/index.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import {
   Dialog, DialogActions, DialogContent, DialogTitle, Button, TextField,
+  Typography,
 } from '@mui/material';
 import { useDispatch, useSelector } from 'react-redux';
 import {
@@ -12,7 +13,7 @@ import initialSiteConditionState from '../../features/siteConditionSlice/state';
 import { historyStates } from '../../features/userSlice/state';
 import { setSiteConditionRedux } from '../../features/siteConditionSlice/actions';
 
-const HistoryDialog = () => {
+const HistoryDialog = ({ setStep }) => {
   const [error, setError] = useState(false);
   const [helperText, setHelperText] = useState('');
   const [historyName, setHistoryName] = useState('');
@@ -61,6 +62,8 @@ const HistoryDialog = () => {
   };
 
   const handleUpdate = () => {
+    // return to first step
+    setStep(0);
     // reset redux
     dispatch(setCalculatorRedux(initialCalculatorState));
     dispatch(setSiteConditionRedux(initialSiteConditionState));
@@ -73,34 +76,6 @@ const HistoryDialog = () => {
   const handleCancel = () => {
     resetDialogState();
   };
-
-  // const handleClose = (selection) => {
-  //   if (selection === 'YES') {
-  //     if (from === historyDialogFromEnums.siteCondition) {
-  //       if (!nameValidation()) return;
-  //       // if there's already an imported history existed, cleanup calculator redux(except for crops)
-  //       if (historyState === historyStates.imported) dispatch(setCalculatorRedux({ ...initialState, crops }));
-  //       dispatch(setHistoryStateRedux(historyStates.new));
-  //       setOpenModal(false);
-  //     }
-  //     // on the complete page, update/save the calculation
-  //     if (from === historyDialogFromEnums.completePage) {
-  //       if (historyState === historyStates.updated) {
-  //         // if history is updated but name is not changed, not run nameValidation again
-  //         if (selectedHistory.label !== historyName && !nameValidation()) return;
-  //         saveHistory(selectedHistory.id, historyName);
-  //       } else if (historyState === historyStates.new) {
-  //         if (!nameValidation()) return;
-  //         saveHistory();
-  //       }
-  //     }
-  //     dispatch(setCalculationNameRedux(historyName));
-  //     dispatch(setSelectedHistoryRedux(null));
-  //   }
-  //   setError(false);
-  //   setHelperText('');
-  //   setOpen(false);
-  // };
 
   // initially set calculation name
   useEffect(() => {
@@ -130,18 +105,20 @@ const HistoryDialog = () => {
         {type === 'update'
           && (
           <DialogContent>
-            <span style={{ color: 'red' }}>Warning: </span>
-            Making changes may affect the results of subsequent steps
-            that you have saved. Please create a new record instead.
+            <Typography>
+              <span style={{ color: 'red' }}>Warning: </span>
+              Making changes may affect the results of subsequent steps
+              that you have saved. Please create a new record instead.
+            </Typography>
           </DialogContent>
           )}
       </DialogContent>
       <DialogActions>
         {type === 'add'
-            && <Button onClick={handleCreate}>Create</Button>}
+            && <Button onClick={handleCreate} variant="contained">Create</Button>}
         {type === 'update'
-            && <Button onClick={handleUpdate}>Create a new record</Button>}
-        <Button onClick={handleCancel}>Cancel</Button>
+            && <Button onClick={handleUpdate} variant="contained">Create a new record</Button>}
+        <Button onClick={handleCancel} variant="contained">Cancel</Button>
       </DialogActions>
 
     </Dialog>

--- a/src/components/HistoryDialog/index.js
+++ b/src/components/HistoryDialog/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import {
   Dialog, DialogActions, DialogContent, DialogTitle, Button, TextField,
   Typography,
@@ -19,7 +19,7 @@ const HistoryDialog = ({ setStep, setSiteConditionStep }) => {
   const [historyName, setHistoryName] = useState('');
 
   const {
-    calculationName, userHistoryList, historyDialogState,
+    userHistoryList, historyDialogState,
   } = useSelector((state) => state.user);
   // const { crops } = useSelector((state) => state.calculator);
   const { open, type } = historyDialogState;
@@ -77,11 +77,6 @@ const HistoryDialog = ({ setStep, setSiteConditionStep }) => {
   const handleCancel = () => {
     resetDialogState();
   };
-
-  // initially set calculation name
-  useEffect(() => {
-    setHistoryName(calculationName);
-  }, []);
 
   return (
     <Dialog open={open}>

--- a/src/components/HistoryDialog/index.js
+++ b/src/components/HistoryDialog/index.js
@@ -9,7 +9,7 @@ import {
 import { setCalculatorRedux } from '../../features/calculatorSlice/actions';
 import initialCalculatorState from '../../features/calculatorSlice/state';
 import initialSiteConditionState from '../../features/siteConditionSlice/state';
-import { historyState } from '../../features/userSlice/state';
+import { historyStates } from '../../features/userSlice/state';
 import { setSiteConditionRedux } from '../../features/siteConditionSlice/actions';
 
 const HistoryDialog = () => {
@@ -51,7 +51,7 @@ const HistoryDialog = () => {
       dispatch(setCalculatorRedux(initialCalculatorState));
       dispatch(setSiteConditionRedux(initialSiteConditionState));
       dispatch(setSelectedHistoryRedux({ label: historyName, id: null }));
-      dispatch(setHistoryStateRedux(historyState.new));
+      dispatch(setHistoryStateRedux(historyStates.new));
     } else {
       setError(true);
       setHelperText('Name invalid or already exists!');
@@ -65,7 +65,7 @@ const HistoryDialog = () => {
     dispatch(setCalculatorRedux(initialCalculatorState));
     dispatch(setSiteConditionRedux(initialSiteConditionState));
     dispatch(setSelectedHistoryRedux(null));
-    dispatch(setHistoryStateRedux(historyState.none));
+    dispatch(setHistoryStateRedux(historyStates.none));
     // open dialog and set dialog state as add
     handleOpenDialog(true, 'add');
   };
@@ -79,17 +79,17 @@ const HistoryDialog = () => {
   //     if (from === historyDialogFromEnums.siteCondition) {
   //       if (!nameValidation()) return;
   //       // if there's already an imported history existed, cleanup calculator redux(except for crops)
-  //       if (historyState === historyState.imported) dispatch(setCalculatorRedux({ ...initialState, crops }));
-  //       dispatch(setHistoryStateRedux(historyState.new));
+  //       if (historyState === historyStates.imported) dispatch(setCalculatorRedux({ ...initialState, crops }));
+  //       dispatch(setHistoryStateRedux(historyStates.new));
   //       setOpenModal(false);
   //     }
   //     // on the complete page, update/save the calculation
   //     if (from === historyDialogFromEnums.completePage) {
-  //       if (historyState === historyState.updated) {
+  //       if (historyState === historyStates.updated) {
   //         // if history is updated but name is not changed, not run nameValidation again
   //         if (selectedHistory.label !== historyName && !nameValidation()) return;
   //         saveHistory(selectedHistory.id, historyName);
-  //       } else if (historyState === historyState.new) {
+  //       } else if (historyState === historyStates.new) {
   //         if (!nameValidation()) return;
   //         saveHistory();
   //       }

--- a/src/components/HistoryDialog/index.js
+++ b/src/components/HistoryDialog/index.js
@@ -113,13 +113,26 @@ const HistoryDialog = ({ setStep, setSiteConditionStep }) => {
             </Typography>
           </DialogContent>
           )}
+        {type === 'warning'
+          && (
+          <DialogContent>
+            <Typography>
+              <span style={{ color: 'red' }}>Warning: </span>
+              Making changes on this page will erase the results of subsequent steps you have saved
+              and initiate a new calculation. Please be aware of this.
+            </Typography>
+          </DialogContent>
+          )}
       </DialogContent>
       <DialogActions>
         {type === 'add'
             && <Button onClick={handleCreate} variant="contained">Create</Button>}
         {type === 'update'
             && <Button onClick={handleUpdate} variant="contained">Create a new record</Button>}
-        <Button onClick={handleCancel} variant="contained">Cancel</Button>
+        {type === 'warning'
+            && <Button onClick={handleCancel} variant="contained">Confirm</Button>}
+        {type !== 'warning'
+            && <Button onClick={handleCancel} variant="contained">Cancel</Button>}
       </DialogActions>
 
     </Dialog>

--- a/src/components/HistoryDialog/index.js
+++ b/src/components/HistoryDialog/index.js
@@ -13,7 +13,7 @@ import initialSiteConditionState from '../../features/siteConditionSlice/state';
 import { historyStates } from '../../features/userSlice/state';
 import { setSiteConditionRedux } from '../../features/siteConditionSlice/actions';
 
-const HistoryDialog = ({ setStep }) => {
+const HistoryDialog = ({ setStep, setSiteConditionStep }) => {
   const [error, setError] = useState(false);
   const [helperText, setHelperText] = useState('');
   const [historyName, setHistoryName] = useState('');
@@ -64,6 +64,7 @@ const HistoryDialog = ({ setStep }) => {
   const handleUpdate = () => {
     // return to first step
     setStep(0);
+    setSiteConditionStep(1);
     // reset redux
     dispatch(setCalculatorRedux(initialCalculatorState));
     dispatch(setSiteConditionRedux(initialSiteConditionState));

--- a/src/components/HistoryDialog/index.js
+++ b/src/components/HistoryDialog/index.js
@@ -21,7 +21,6 @@ const HistoryDialog = ({ setStep, setSiteConditionStep }) => {
   const {
     userHistoryList, historyDialogState,
   } = useSelector((state) => state.user);
-  // const { crops } = useSelector((state) => state.calculator);
   const { open, type } = historyDialogState;
 
   const dispatch = useDispatch();

--- a/src/components/HistoryDialog/index.js
+++ b/src/components/HistoryDialog/index.js
@@ -1,76 +1,106 @@
 import React, { useEffect, useState } from 'react';
 import {
-  Dialog, DialogActions, DialogContent, DialogTitle, Button, TextField, Typography,
+  Dialog, DialogActions, DialogContent, DialogTitle, Button, TextField,
 } from '@mui/material';
 import { useDispatch, useSelector } from 'react-redux';
-import { setCalculationNameRedux, setFromUserHistoryRedux, setSelectedHistoryRedux } from '../../features/userSlice/actions';
-import useUserHistory from '../../shared/hooks/useUserHistory';
+import {
+  setHistoryStateRedux, setHistoryDialogStateRedux, setSelectedHistoryRedux,
+} from '../../features/userSlice/actions';
 import { setCalculatorRedux } from '../../features/calculatorSlice/actions';
-import initialState from '../../features/calculatorSlice/state';
+import initialCalculatorState from '../../features/calculatorSlice/state';
+import initialSiteConditionState from '../../features/siteConditionSlice/state';
 import { historyState } from '../../features/userSlice/state';
+import { setSiteConditionRedux } from '../../features/siteConditionSlice/actions';
 
-export const historyDialogFromEnums = {
-  siteCondition: 'siteConditoin',
-  completePage: 'completePage',
-};
-
-const HistoryDialog = ({
-  buttonLabel, from, token, setOpenModal,
-}) => {
-  const [open, setOpen] = useState(false);
+const HistoryDialog = () => {
   const [error, setError] = useState(false);
   const [helperText, setHelperText] = useState('');
   const [historyName, setHistoryName] = useState('');
 
-  const { saveHistory } = useUserHistory(token);
-
   const {
-    calculationName, fromUserHistory, userHistoryList, selectedHistory,
+    calculationName, userHistoryList, historyDialogState,
   } = useSelector((state) => state.user);
-  const { crops } = useSelector((state) => state.calculator);
+  // const { crops } = useSelector((state) => state.calculator);
+  const { open, type } = historyDialogState;
 
   const dispatch = useDispatch();
 
-  const nameValidation = () => {
-    if (userHistoryList.find((h) => h.label === historyName)) {
-      setError(true);
-      setHelperText('A calculation with same name already exists!');
-      return false;
-    }
-    return true;
+  // eslint-disable-next-line no-shadow
+  const handleOpenDialog = (open, type = 'add') => {
+    dispatch(setHistoryDialogStateRedux({ open, type }));
   };
 
-  const handleOpenDialog = () => {
-    setOpen(true);
+  const nameValidation = (name) => {
+    if (name === '') return false;
+    const result = userHistoryList.find((history) => history.label === name);
+    if (result === undefined) return true;
+    return false;
   };
 
-  const handleClose = (selection) => {
-    if (selection === 'YES') {
-      if (from === historyDialogFromEnums.siteCondition) {
-        if (!nameValidation()) return;
-        // if there's already an imported history existed, cleanup calculator redux(except for crops)
-        if (fromUserHistory === historyState.imported) dispatch(setCalculatorRedux({ ...initialState, crops }));
-        dispatch(setFromUserHistoryRedux(historyState.new));
-        setOpenModal(false);
-      }
-      // on the complete page, update/save the calculation
-      if (from === historyDialogFromEnums.completePage) {
-        if (fromUserHistory === historyState.updated) {
-          // if history is updated but name is not changed, not run nameValidation again
-          if (selectedHistory.label !== historyName && !nameValidation()) return;
-          saveHistory(selectedHistory.id, historyName);
-        } else if (fromUserHistory === historyState.new) {
-          if (!nameValidation()) return;
-          saveHistory();
-        }
-      }
-      dispatch(setCalculationNameRedux(historyName));
-      dispatch(setSelectedHistoryRedux(null));
-    }
+  const resetDialogState = () => {
+    handleOpenDialog(false);
+    setHistoryName('');
     setError(false);
     setHelperText('');
-    setOpen(false);
   };
+
+  const handleCreate = () => {
+    const result = nameValidation(historyName);
+    if (result) {
+      // reset redux
+      dispatch(setCalculatorRedux(initialCalculatorState));
+      dispatch(setSiteConditionRedux(initialSiteConditionState));
+      dispatch(setSelectedHistoryRedux({ label: historyName, id: null }));
+      dispatch(setHistoryStateRedux(historyState.new));
+    } else {
+      setError(true);
+      setHelperText('Name invalid or already exists!');
+      return;
+    }
+    resetDialogState();
+  };
+
+  const handleUpdate = () => {
+    // reset redux
+    dispatch(setCalculatorRedux(initialCalculatorState));
+    dispatch(setSiteConditionRedux(initialSiteConditionState));
+    dispatch(setSelectedHistoryRedux(null));
+    dispatch(setHistoryStateRedux(historyState.none));
+    // open dialog and set dialog state as add
+    handleOpenDialog(true, 'add');
+  };
+
+  const handleCancel = () => {
+    resetDialogState();
+  };
+
+  // const handleClose = (selection) => {
+  //   if (selection === 'YES') {
+  //     if (from === historyDialogFromEnums.siteCondition) {
+  //       if (!nameValidation()) return;
+  //       // if there's already an imported history existed, cleanup calculator redux(except for crops)
+  //       if (historyState === historyState.imported) dispatch(setCalculatorRedux({ ...initialState, crops }));
+  //       dispatch(setHistoryStateRedux(historyState.new));
+  //       setOpenModal(false);
+  //     }
+  //     // on the complete page, update/save the calculation
+  //     if (from === historyDialogFromEnums.completePage) {
+  //       if (historyState === historyState.updated) {
+  //         // if history is updated but name is not changed, not run nameValidation again
+  //         if (selectedHistory.label !== historyName && !nameValidation()) return;
+  //         saveHistory(selectedHistory.id, historyName);
+  //       } else if (historyState === historyState.new) {
+  //         if (!nameValidation()) return;
+  //         saveHistory();
+  //       }
+  //     }
+  //     dispatch(setCalculationNameRedux(historyName));
+  //     dispatch(setSelectedHistoryRedux(null));
+  //   }
+  //   setError(false);
+  //   setHelperText('');
+  //   setOpen(false);
+  // };
 
   // initially set calculation name
   useEffect(() => {
@@ -78,19 +108,14 @@ const HistoryDialog = ({
   }, []);
 
   return (
-    <>
-      <Dialog open={open}>
-        <DialogTitle>
-          {from === historyDialogFromEnums.siteCondition
-            ? 'Do you want to create a new calculation and save it?'
-            : 'Do you want to save this calculation?'}
-        </DialogTitle>
-        <Typography pl="1.5rem">
-          {from === historyDialogFromEnums.siteCondition
-            ? 'You can also save it after the calculation.'
-            : ''}
-        </Typography>
-        <DialogContent>
+    <Dialog open={open}>
+      <DialogTitle>
+        { type === 'add' && 'Are you creating a new record?'}
+        { type === 'update' && 'Are you updating your record?'}
+      </DialogTitle>
+      <DialogContent>
+        {type === 'add'
+          && (
           <TextField
             autoFocus
             fullWidth
@@ -101,17 +126,25 @@ const HistoryDialog = ({
             error={error}
             helperText={helperText}
           />
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => handleClose('YES')}>Save</Button>
-          <Button onClick={() => handleClose('NO')}>Cancel</Button>
-        </DialogActions>
+          )}
+        {type === 'update'
+          && (
+          <DialogContent>
+            <span style={{ color: 'red' }}>Warning: </span>
+            Making changes may affect the results of subsequent steps
+            that you have saved. Please create a new record instead.
+          </DialogContent>
+          )}
+      </DialogContent>
+      <DialogActions>
+        {type === 'add'
+            && <Button onClick={handleCreate}>Create</Button>}
+        {type === 'update'
+            && <Button onClick={handleUpdate}>Create a new record</Button>}
+        <Button onClick={handleCancel}>Cancel</Button>
+      </DialogActions>
 
-      </Dialog>
-      <Button variant="contained" onClick={handleOpenDialog}>
-        {buttonLabel}
-      </Button>
-    </>
+    </Dialog>
   );
 };
 export default HistoryDialog;

--- a/src/components/StepsList/index.js
+++ b/src/components/StepsList/index.js
@@ -14,7 +14,7 @@ import { useDispatch } from 'react-redux';
 import { calculatorList } from '../../shared/data/dropdown';
 import { resetCalculator } from '../../features/calculatorSlice';
 import {
-  setCalculationNameRedux, setHistoryStateRedux, setSelectedHistoryRedux,
+  setHistoryStateRedux, setSelectedHistoryRedux,
 } from '../../features/userSlice/actions';
 import { historyStates } from '../../features/userSlice/state';
 
@@ -64,7 +64,6 @@ const StepsList = ({ activeStep, setActiveStep, availableSteps }) => {
     setCompletedStep(-1);
     dispatch(resetCalculator());
     dispatch(setHistoryStateRedux(historyStates.none));
-    dispatch(setCalculationNameRedux(''));
     dispatch(setSelectedHistoryRedux(null));
   };
   const tooltipTitle = () => {

--- a/src/components/StepsList/index.js
+++ b/src/components/StepsList/index.js
@@ -14,7 +14,7 @@ import { useDispatch } from 'react-redux';
 import { calculatorList } from '../../shared/data/dropdown';
 import { resetCalculator } from '../../features/calculatorSlice';
 import {
-  setCalculationNameRedux, setFromUserHistoryRedux, setSelectedHistoryRedux,
+  setCalculationNameRedux, setHistoryStateRedux, setSelectedHistoryRedux,
 } from '../../features/userSlice/actions';
 import { historyState } from '../../features/userSlice/state';
 
@@ -63,7 +63,7 @@ const StepsList = ({ activeStep, setActiveStep, availableSteps }) => {
     setActiveStep(0);
     setCompletedStep(-1);
     dispatch(resetCalculator());
-    dispatch(setFromUserHistoryRedux(historyState.none));
+    dispatch(setHistoryStateRedux(historyState.none));
     dispatch(setCalculationNameRedux(''));
     dispatch(setSelectedHistoryRedux(null));
   };

--- a/src/components/StepsList/index.js
+++ b/src/components/StepsList/index.js
@@ -16,7 +16,7 @@ import { resetCalculator } from '../../features/calculatorSlice';
 import {
   setCalculationNameRedux, setHistoryStateRedux, setSelectedHistoryRedux,
 } from '../../features/userSlice/actions';
-import { historyState } from '../../features/userSlice/state';
+import { historyStates } from '../../features/userSlice/state';
 
 /*
 {
@@ -63,7 +63,7 @@ const StepsList = ({ activeStep, setActiveStep, availableSteps }) => {
     setActiveStep(0);
     setCompletedStep(-1);
     dispatch(resetCalculator());
-    dispatch(setHistoryStateRedux(historyState.none));
+    dispatch(setHistoryStateRedux(historyStates.none));
     dispatch(setCalculationNameRedux(''));
     dispatch(setSelectedHistoryRedux(null));
   };

--- a/src/components/StepsList/index.js
+++ b/src/components/StepsList/index.js
@@ -34,7 +34,9 @@ import { historyStates } from '../../features/userSlice/state';
 }
 */
 
-const StepsList = ({ activeStep, setActiveStep, availableSteps }) => {
+const StepsList = ({
+  activeStep, setActiveStep, availableSteps, setSiteConditionStep,
+}) => {
   const [hovering, setHovering] = useState(false);
   const [visible, setVisible] = useState(false);
 
@@ -61,6 +63,7 @@ const StepsList = ({ activeStep, setActiveStep, availableSteps }) => {
 
   const handleRestart = () => {
     setActiveStep(0);
+    setSiteConditionStep(1);
     setCompletedStep(-1);
     dispatch(resetCalculator());
     dispatch(setHistoryStateRedux(historyStates.none));

--- a/src/features/userSlice/actions.js
+++ b/src/features/userSlice/actions.js
@@ -1,10 +1,8 @@
 /* eslint-disable import/prefer-default-export */
 import {
-  setCalculationName, setHistoryState, setUserHistoryList, setSelectedHistory, setAlertState,
+  setHistoryState, setUserHistoryList, setSelectedHistory, setAlertState,
   setHistoryDialogState,
 } from './index';
-
-export const setCalculationNameRedux = (calculationName) => setCalculationName({ calculationName });
 
 export const setHistoryStateRedux = (historyState) => setHistoryState({ historyState });
 

--- a/src/features/userSlice/actions.js
+++ b/src/features/userSlice/actions.js
@@ -1,14 +1,17 @@
 /* eslint-disable import/prefer-default-export */
 import {
-  setCalculationName, setFromUserHistory, setUserHistoryList, setSelectedHistory, setAlertState,
+  setCalculationName, setHistoryState, setUserHistoryList, setSelectedHistory, setAlertState,
+  setHistoryDialogState,
 } from './index';
 
 export const setCalculationNameRedux = (calculationName) => setCalculationName({ calculationName });
 
-export const setFromUserHistoryRedux = (fromUserHistory) => setFromUserHistory({ fromUserHistory });
+export const setHistoryStateRedux = (historyState) => setHistoryState({ historyState });
 
 export const setUserHistoryListRedux = (userHistoryList) => setUserHistoryList({ userHistoryList });
 
 export const setSelectedHistoryRedux = (selectedHistory) => setSelectedHistory({ selectedHistory });
 
 export const setAlertStateRedux = ({ open, severity, message }) => setAlertState({ open, severity, message });
+
+export const setHistoryDialogStateRedux = ({ open, type }) => setHistoryDialogState({ open, type });

--- a/src/features/userSlice/index.js
+++ b/src/features/userSlice/index.js
@@ -5,11 +5,6 @@ const userSlice = createSlice({
   name: 'user',
   initialState,
   reducers: {
-    // TODO: whether to remove this redux state
-    setCalculationName: (state, { payload }) => {
-      const { calculationName } = payload;
-      return { ...state, calculationName };
-    },
     setHistoryState: (state, { payload }) => {
       const { historyState } = payload;
       return { ...state, historyState };
@@ -28,7 +23,7 @@ const userSlice = createSlice({
 });
 
 export const {
-  setCalculationName, setHistoryState, setUserHistoryList, setSelectedHistory, setAlertState,
+  setHistoryState, setUserHistoryList, setSelectedHistory, setAlertState,
   setHistoryDialogState,
 } = userSlice.actions;
 

--- a/src/features/userSlice/index.js
+++ b/src/features/userSlice/index.js
@@ -9,9 +9,9 @@ const userSlice = createSlice({
       const { calculationName } = payload;
       return { ...state, calculationName };
     },
-    setFromUserHistory: (state, { payload }) => {
-      const { fromUserHistory } = payload;
-      return { ...state, fromUserHistory };
+    setHistoryState: (state, { payload }) => {
+      const { historyState } = payload;
+      return { ...state, historyState };
     },
     setUserHistoryList: (state, { payload }) => {
       const { userHistoryList } = payload;
@@ -22,11 +22,13 @@ const userSlice = createSlice({
       return { ...state, selectedHistory };
     },
     setAlertState: (state, { payload }) => ({ ...state, alertState: { ...state.alertState, ...payload } }),
+    setHistoryDialogState: (state, { payload }) => ({ ...state, historyDialogState: { ...payload } }),
   },
 });
 
 export const {
-  setCalculationName, setFromUserHistory, setUserHistoryList, setSelectedHistory, setAlertState,
+  setCalculationName, setHistoryState, setUserHistoryList, setSelectedHistory, setAlertState,
+  setHistoryDialogState,
 } = userSlice.actions;
 
 export default userSlice;

--- a/src/features/userSlice/index.js
+++ b/src/features/userSlice/index.js
@@ -5,6 +5,7 @@ const userSlice = createSlice({
   name: 'user',
   initialState,
   reducers: {
+    // TODO: whether to remove this redux state
     setCalculationName: (state, { payload }) => {
       const { calculationName } = payload;
       return { ...state, calculationName };

--- a/src/features/userSlice/state.js
+++ b/src/features/userSlice/state.js
@@ -6,7 +6,6 @@ export const historyStates = {
 };
 
 const initialState = {
-  calculationName: '',
   historyState: historyStates.none,
   userHistoryList: [],
   selectedHistory: null,

--- a/src/features/userSlice/state.js
+++ b/src/features/userSlice/state.js
@@ -1,4 +1,4 @@
-export const historyState = {
+export const historyStates = {
   none: 'none',
   new: 'new',
   imported: 'imported',
@@ -7,7 +7,7 @@ export const historyState = {
 
 const initialState = {
   calculationName: '',
-  historyState: historyState.none,
+  historyState: historyStates.none,
   userHistoryList: [],
   selectedHistory: null,
   alertState: {

--- a/src/features/userSlice/state.js
+++ b/src/features/userSlice/state.js
@@ -7,13 +7,17 @@ export const historyState = {
 
 const initialState = {
   calculationName: '',
-  fromUserHistory: historyState.none,
+  historyState: historyState.none,
   userHistoryList: [],
   selectedHistory: null,
   alertState: {
     open: false,
     severity: 'error',
     message: 'Network Error - Try again later or refresh the page!',
+  },
+  historyDialogState: {
+    open: false,
+    type: 'add',
   },
 };
 

--- a/src/pages/Calculator/Steps/ConfirmPlan/ExportModal.js
+++ b/src/pages/Calculator/Steps/ConfirmPlan/ExportModal.js
@@ -3,9 +3,7 @@ import {
   Button, Modal, Box, Typography, Grid,
 } from '@mui/material';
 import { useSelector } from 'react-redux';
-import { useAuth0 } from '@auth0/auth0-react';
 import { handleDownload } from '../../../../shared/utils/exportExcel';
-import HistoryDialog, { historyDialogFromEnums } from '../../../../components/HistoryDialog';
 
 const modalStyle = {
   position: 'absolute',
@@ -31,14 +29,12 @@ const buttonStyles = {
   borderRadius: '26px',
 };
 
-const ExportModal = ({ token }) => {
+const ExportModal = () => {
   const [open, setOpen] = useState(false);
 
   const siteCondition = useSelector((state) => state.siteCondition);
   const calculatorRedux = useSelector((state) => state.calculator);
   const { council } = siteCondition;
-
-  const { isAuthenticated } = useAuth0();
 
   const handleExportcsv = () => {
     handleDownload(
@@ -70,18 +66,6 @@ const ExportModal = ({ token }) => {
             <Grid item xs={12} display="flex" justifyContent="center">
               <Button variant="contained" onClick={handleExportcsv}>Export to csv</Button>
             </Grid>
-
-            {isAuthenticated
-              && (
-              <Grid item xs={12} display="flex" justifyContent="center">
-                <HistoryDialog
-                  buttonLabel="Save this calculation"
-                  from={historyDialogFromEnums.completePage}
-                  token={token}
-                  setOpenModal={setOpen}
-                />
-              </Grid>
-              )}
           </Grid>
 
         </Box>

--- a/src/pages/Calculator/Steps/ConfirmPlan/form.js
+++ b/src/pages/Calculator/Steps/ConfirmPlan/form.js
@@ -7,10 +7,11 @@ import { useDispatch, useSelector } from 'react-redux';
 import NumberTextField from '../../../../components/NumberTextField';
 import DSTTextField from '../../../../components/DSTTextField';
 import NRCSStandards from './NRCSStandards';
-
-import '../steps.scss';
 import { setOptionRedux } from '../../../../features/calculatorSlice/actions';
 import { setAcresRedux } from '../../../../features/siteConditionSlice/actions';
+import { historyStates } from '../../../../features/userSlice/state';
+import { setHistoryStateRedux } from '../../../../features/userSlice/actions';
+import '../steps.scss';
 
 const ConfirmPlanForm = ({
   nrcsResult, seedsSelected, calculatorResult, options,
@@ -21,6 +22,7 @@ const ConfirmPlanForm = ({
   const dispatch = useDispatch();
 
   const { checkNRCSStandards } = useSelector((state) => state.siteCondition);
+  const { historyState } = useSelector((state) => state.user);
 
   const renderStepsForm = (label1, label2, label3) => (
     matchesMd && (
@@ -73,6 +75,7 @@ const ConfirmPlanForm = ({
                 seedsSelected.forEach((s) => {
                   dispatch(setOptionRedux(s.label, { ...options[s.label], acres: val }));
                 });
+                if (historyState === historyStates.imported) dispatch(setHistoryStateRedux(historyStates.updated));
               }}
             />
           </Grid>
@@ -99,9 +102,12 @@ const ConfirmPlanForm = ({
             <NumberTextField
               label="Cost per Pound"
               value={result.costPerPound}
-              onChange={(val) => dispatch(
-                setOptionRedux(seed.label, { ...options[seed.label], costPerPound: val }),
-              )}
+              onChange={(val) => {
+                dispatch(
+                  setOptionRedux(seed.label, { ...options[seed.label], costPerPound: val }),
+                );
+                if (historyState === historyStates.imported) dispatch(setHistoryStateRedux(historyStates.updated));
+              }}
             />
           </Grid>
           <Grid item xs={3} />

--- a/src/pages/Calculator/Steps/ConfirmPlan/index.js
+++ b/src/pages/Calculator/Steps/ConfirmPlan/index.js
@@ -16,7 +16,7 @@ const defaultResult = {
   totalCost: 0,
 };
 
-const ConfirmPlan = ({ calculator, token }) => {
+const ConfirmPlan = ({ calculator }) => {
   const siteCondition = useSelector((state) => state.siteCondition);
   const calculatorRedux = useSelector((state) => state.calculator);
   const { council, checkNRCSStandards } = siteCondition;
@@ -69,7 +69,7 @@ const ConfirmPlan = ({ calculator, token }) => {
 
         {/* Export Button */}
         <Grid item xs={12} display="flex" justifyContent="flex-end" pt="5px">
-          <ExportModal token={token} />
+          <ExportModal />
         </Grid>
 
         {/* Charts */}

--- a/src/pages/Calculator/Steps/MixRatios/index.js
+++ b/src/pages/Calculator/Steps/MixRatios/index.js
@@ -23,7 +23,7 @@ import { setOptionRedux, setMixRatioOptionRedux } from '../../../../features/cal
 import { pieChartUnits } from '../../../../shared/data/units';
 import '../steps.scss';
 import { setAlertStateRedux, setHistoryStateRedux } from '../../../../features/userSlice/actions';
-import { historyState } from '../../../../features/userSlice/state';
+import { historyStates } from '../../../../features/userSlice/state';
 
 const getCalculatorResult = (council) => {
   const defaultResultMCCC = {
@@ -125,7 +125,7 @@ const MixRatio = ({
     const seedingRateCalculator = createCalculator(seedsSelected, council, regions, userInput);
     setCalculator(seedingRateCalculator);
     // If historyState is imported, not init options, use mixRatioOptions instead
-    if (historyState !== historyState.imported) {
+    if (historyState !== historyStates.imported) {
       seedsSelected.forEach((seed) => {
         // if percentOfRate is not null, skip this step(this happens when add new crop for a imported history)
         if (mixRatioOptions[seed.label].percentOfRate === null) {
@@ -168,7 +168,7 @@ const MixRatio = ({
         }));
       }
       // if history is not imported, update mixRatioOptions to options
-      if (historyState !== historyState.imported) dispatch(setOptionRedux(seed.label, seedOption));
+      if (historyState !== historyStates.imported) dispatch(setOptionRedux(seed.label, seedOption));
       // if history is updated, this will remove previously imported options redux and set it as mixRatioOptions
     });
     // calculate piechart data
@@ -208,8 +208,8 @@ const MixRatio = ({
       message: 'You now have a custom mix. You can edit this information in furthur steps.',
     }));
     dispatch(setMixRatioOptionRedux(seed.label, { ...mixRatioOptions[seed.label], [option]: value }));
-    // set historyState.updated if change anything
-    if (historyState === historyState.imported) dispatch(setHistoryStateRedux(historyState.updated));
+    // set historyStates.updated if change anything
+    if (historyState === historyStates.imported) dispatch(setHistoryStateRedux(historyStates.updated));
   };
 
   // handler for click to open accordion

--- a/src/pages/Calculator/Steps/MixRatios/index.js
+++ b/src/pages/Calculator/Steps/MixRatios/index.js
@@ -183,9 +183,6 @@ const MixRatio = ({
     } = calculatePieChartData(seedsSelected, calculator, mixRatioOptions);
     setPieChartData({ seedingRateArray, plantsPerSqftArray, seedsPerSqftArray });
     setPrevOptions(mixRatioOptions);
-    // when options change, set mixRatiosOptions in redux
-    // FIXME: maybe need to think a little bit more situations
-    // if (!historyState) dispatch(setMixRatioOptionsRedux(options));
   }, [mixRatioOptions, initCalculator]);
 
   // expand related accordion based on sidebar click

--- a/src/pages/Calculator/Steps/MixRatios/index.js
+++ b/src/pages/Calculator/Steps/MixRatios/index.js
@@ -22,7 +22,7 @@ import {
 import { setOptionRedux, setMixRatioOptionRedux } from '../../../../features/calculatorSlice/actions';
 import { pieChartUnits } from '../../../../shared/data/units';
 import '../steps.scss';
-import { setAlertStateRedux, setHistoryStateRedux } from '../../../../features/userSlice/actions';
+import { setAlertStateRedux, setHistoryStateRedux, setHistoryDialogStateRedux } from '../../../../features/userSlice/actions';
 import { historyStates } from '../../../../features/userSlice/state';
 
 const getCalculatorResult = (council) => {
@@ -117,8 +117,12 @@ const MixRatio = ({
     }, {}),
   );
 
-  // initialize calculator, set initial options
+  // initialize calculator, set initial options, open warning dialog if history is imported
   useEffect(() => {
+    if (historyState === historyStates.imported) {
+      dispatch(setHistoryDialogStateRedux({ open: true, type: 'warning' }));
+    }
+
     const userInput = createUserInput(soilDrainage, plantingDate, acres);
     // use a region object array for sdk init
     const regions = [{ label: county }];

--- a/src/pages/Calculator/Steps/MixRatios/index.js
+++ b/src/pages/Calculator/Steps/MixRatios/index.js
@@ -22,7 +22,7 @@ import {
 import { setOptionRedux, setMixRatioOptionRedux } from '../../../../features/calculatorSlice/actions';
 import { pieChartUnits } from '../../../../shared/data/units';
 import '../steps.scss';
-import { setAlertStateRedux, setFromUserHistoryRedux } from '../../../../features/userSlice/actions';
+import { setAlertStateRedux, setHistoryStateRedux } from '../../../../features/userSlice/actions';
 import { historyState } from '../../../../features/userSlice/state';
 
 const getCalculatorResult = (council) => {
@@ -86,7 +86,7 @@ const MixRatio = ({
   const {
     council, soilDrainage, plantingDate, acres, county,
   } = useSelector((state) => state.siteCondition);
-  const { fromUserHistory } = useSelector((state) => state.user);
+  const { historyState } = useSelector((state) => state.user);
 
   const [calculatorResult, setCalculatorResult] = useState(
     seedsSelected.reduce((res, seed) => {
@@ -125,7 +125,7 @@ const MixRatio = ({
     const seedingRateCalculator = createCalculator(seedsSelected, council, regions, userInput);
     setCalculator(seedingRateCalculator);
     // If historyState is imported, not init options, use mixRatioOptions instead
-    if (fromUserHistory !== historyState.imported) {
+    if (historyState !== historyState.imported) {
       seedsSelected.forEach((seed) => {
         // if percentOfRate is not null, skip this step(this happens when add new crop for a imported history)
         if (mixRatioOptions[seed.label].percentOfRate === null) {
@@ -168,7 +168,7 @@ const MixRatio = ({
         }));
       }
       // if history is not imported, update mixRatioOptions to options
-      if (fromUserHistory !== historyState.imported) dispatch(setOptionRedux(seed.label, seedOption));
+      if (historyState !== historyState.imported) dispatch(setOptionRedux(seed.label, seedOption));
       // if history is updated, this will remove previously imported options redux and set it as mixRatioOptions
     });
     // calculate piechart data
@@ -181,7 +181,7 @@ const MixRatio = ({
     setPrevOptions(mixRatioOptions);
     // when options change, set mixRatiosOptions in redux
     // FIXME: maybe need to think a little bit more situations
-    // if (!fromUserHistory) dispatch(setMixRatioOptionsRedux(options));
+    // if (!historyState) dispatch(setMixRatioOptionsRedux(options));
   }, [mixRatioOptions, initCalculator]);
 
   // expand related accordion based on sidebar click
@@ -209,7 +209,7 @@ const MixRatio = ({
     }));
     dispatch(setMixRatioOptionRedux(seed.label, { ...mixRatioOptions[seed.label], [option]: value }));
     // set historyState.updated if change anything
-    if (fromUserHistory === historyState.imported) dispatch(setFromUserHistoryRedux(historyState.updated));
+    if (historyState === historyState.imported) dispatch(setHistoryStateRedux(historyState.updated));
   };
 
   // handler for click to open accordion

--- a/src/pages/Calculator/Steps/MixSeedingRate/index.js
+++ b/src/pages/Calculator/Steps/MixSeedingRate/index.js
@@ -16,7 +16,7 @@ import {
   setMixSeedingRateRedux, setOptionRedux,
 } from '../../../../features/calculatorSlice/actions';
 import { historyState } from '../../../../features/userSlice/state';
-import { setFromUserHistoryRedux } from '../../../../features/userSlice/actions';
+import { setHistoryStateRedux } from '../../../../features/userSlice/actions';
 import '../steps.scss';
 
 const CustomThumb = (props) => {
@@ -115,7 +115,7 @@ const MixSeedingRate = ({ calculator }) => {
     seedsSelected, options, mixSeedingRate,
     adjustedMixSeedingRate: adjustedRate,
   } = useSelector((state) => state.calculator);
-  const { fromUserHistory } = useSelector((state) => state.user);
+  const { historyState } = useSelector((state) => state.user);
 
   /// ///////////////////////////////////////////////////////
   //                    State Logic                       //
@@ -129,7 +129,7 @@ const MixSeedingRate = ({ calculator }) => {
       dispatch(setOptionRedux(seed.label, { ...prevOptions, managementImpactOnMix }));
     });
     dispatch(setAdjustedMixSeedingRateRedux(adjustedMixSeedingRate));
-    if (fromUserHistory === historyState.imported) dispatch(setFromUserHistoryRedux(historyState.updated));
+    if (historyState === historyState.imported) dispatch(setHistoryStateRedux(historyState.updated));
   };
 
   /// ///////////////////////////////////////////////////////

--- a/src/pages/Calculator/Steps/MixSeedingRate/index.js
+++ b/src/pages/Calculator/Steps/MixSeedingRate/index.js
@@ -15,7 +15,7 @@ import {
   setAdjustedMixSeedingRateRedux,
   setMixSeedingRateRedux, setOptionRedux,
 } from '../../../../features/calculatorSlice/actions';
-import { historyState } from '../../../../features/userSlice/state';
+import { historyStates } from '../../../../features/userSlice/state';
 import { setHistoryStateRedux } from '../../../../features/userSlice/actions';
 import '../steps.scss';
 
@@ -129,7 +129,7 @@ const MixSeedingRate = ({ calculator }) => {
       dispatch(setOptionRedux(seed.label, { ...prevOptions, managementImpactOnMix }));
     });
     dispatch(setAdjustedMixSeedingRateRedux(adjustedMixSeedingRate));
-    if (historyState === historyState.imported) dispatch(setHistoryStateRedux(historyState.updated));
+    if (historyState === historyStates.imported) dispatch(setHistoryStateRedux(historyStates.updated));
   };
 
   /// ///////////////////////////////////////////////////////

--- a/src/pages/Calculator/Steps/ReviewMix/index.js
+++ b/src/pages/Calculator/Steps/ReviewMix/index.js
@@ -20,7 +20,7 @@ import DSTBarChart from '../../../../components/DSTBarChart';
 import SeedingRateCard, { UnitSelection } from '../../../../components/SeedingRateCard';
 import { setBulkSeedingRateRedux, setOptionRedux } from '../../../../features/calculatorSlice/actions';
 import { pieChartUnits, seedDataUnits } from '../../../../shared/data/units';
-import { historyState } from '../../../../features/userSlice/state';
+import { historyStates } from '../../../../features/userSlice/state';
 import { setHistoryStateRedux } from '../../../../features/userSlice/actions';
 import '../steps.scss';
 
@@ -119,7 +119,7 @@ const ReviewMix = ({ calculator }) => {
   // function to handle form value change, update options
   const handleFormValueChange = (seed, option, value) => {
     dispatch(setOptionRedux(seed.label, { ...options[seed.label], [option]: value }));
-    if (historyState === historyState.imported) dispatch(setHistoryStateRedux(historyState.updated));
+    if (historyState === historyStates.imported) dispatch(setHistoryStateRedux(historyStates.updated));
   };
 
   const handleExpandAccordion = (label) => {

--- a/src/pages/Calculator/Steps/ReviewMix/index.js
+++ b/src/pages/Calculator/Steps/ReviewMix/index.js
@@ -21,7 +21,7 @@ import SeedingRateCard, { UnitSelection } from '../../../../components/SeedingRa
 import { setBulkSeedingRateRedux, setOptionRedux } from '../../../../features/calculatorSlice/actions';
 import { pieChartUnits, seedDataUnits } from '../../../../shared/data/units';
 import { historyState } from '../../../../features/userSlice/state';
-import { setFromUserHistoryRedux } from '../../../../features/userSlice/actions';
+import { setHistoryStateRedux } from '../../../../features/userSlice/actions';
 import '../steps.scss';
 
 const getCalculatorResult = (council) => {
@@ -79,7 +79,7 @@ const ReviewMix = ({ calculator }) => {
   const {
     seedsSelected, sideBarSelection, options,
   } = useSelector((state) => state.calculator);
-  const { fromUserHistory } = useSelector((state) => state.user);
+  const { historyState } = useSelector((state) => state.user);
 
   const [prevOptions, setPrevOptions] = useState({});
   const [piechartData, setPieChartData] = useState(defaultPieChartData);
@@ -119,7 +119,7 @@ const ReviewMix = ({ calculator }) => {
   // function to handle form value change, update options
   const handleFormValueChange = (seed, option, value) => {
     dispatch(setOptionRedux(seed.label, { ...options[seed.label], [option]: value }));
-    if (fromUserHistory === historyState.imported) dispatch(setFromUserHistoryRedux(historyState.updated));
+    if (historyState === historyState.imported) dispatch(setHistoryStateRedux(historyState.updated));
   };
 
   const handleExpandAccordion = (label) => {

--- a/src/pages/Calculator/Steps/SeedTagInfo/index.js
+++ b/src/pages/Calculator/Steps/SeedTagInfo/index.js
@@ -18,7 +18,7 @@ import { setOptionRedux } from '../../../../features/calculatorSlice/actions';
 import '../steps.scss';
 import { validateForms } from '../../../../shared/utils/format';
 import { historyState } from '../../../../features/userSlice/state';
-import { setAlertStateRedux, setFromUserHistoryRedux } from '../../../../features/userSlice/actions';
+import { setAlertStateRedux, setHistoryStateRedux } from '../../../../features/userSlice/actions';
 
 const LeftGrid = styled(Grid)({
   '&.MuiGrid-item': {
@@ -51,7 +51,7 @@ const SeedTagInfo = ({
   const dispatch = useDispatch();
   const { council } = useSelector((state) => state.siteCondition);
   const { seedsSelected, options } = useSelector((state) => state.calculator);
-  const { fromUserHistory } = useSelector((state) => state.user);
+  const { historyState } = useSelector((state) => state.user);
 
   const [accordionState, setAccordionState] = useState(
     seedsSelected.reduce((res, seed) => {
@@ -70,7 +70,7 @@ const SeedTagInfo = ({
       message: 'You can also edit this information in furthur steps.',
     }));
     dispatch(setOptionRedux(seedLabel, { ...options[seedLabel], germination: value }));
-    if (fromUserHistory === historyState.imported) dispatch(setFromUserHistoryRedux(historyState.updated));
+    if (historyState === historyState.imported) dispatch(setHistoryStateRedux(historyState.updated));
   };
 
   const updatePurity = (seedLabel, value) => {
@@ -81,12 +81,12 @@ const SeedTagInfo = ({
       message: 'You can also edit this information in furthur steps.',
     }));
     dispatch(setOptionRedux(seedLabel, { ...options[seedLabel], purity: value }));
-    if (fromUserHistory === historyState.imported) dispatch(setFromUserHistoryRedux(historyState.updated));
+    if (historyState === historyState.imported) dispatch(setHistoryStateRedux(historyState.updated));
   };
 
   const updateSeedsPerPound = (seedLabel, value) => {
     dispatch(setOptionRedux(seedLabel, { ...options[seedLabel], seedsPerPound: value }));
-    if (fromUserHistory === historyState.imported) dispatch(setFromUserHistoryRedux(historyState.updated));
+    if (historyState === historyState.imported) dispatch(setHistoryStateRedux(historyState.updated));
   };
 
   const seedsPerPound = (seed) => {

--- a/src/pages/Calculator/Steps/SeedTagInfo/index.js
+++ b/src/pages/Calculator/Steps/SeedTagInfo/index.js
@@ -17,7 +17,7 @@ import NumberTextField from '../../../../components/NumberTextField';
 import { setOptionRedux } from '../../../../features/calculatorSlice/actions';
 import '../steps.scss';
 import { validateForms } from '../../../../shared/utils/format';
-import { historyState } from '../../../../features/userSlice/state';
+import { historyStates } from '../../../../features/userSlice/state';
 import { setAlertStateRedux, setHistoryStateRedux } from '../../../../features/userSlice/actions';
 
 const LeftGrid = styled(Grid)({
@@ -70,7 +70,7 @@ const SeedTagInfo = ({
       message: 'You can also edit this information in furthur steps.',
     }));
     dispatch(setOptionRedux(seedLabel, { ...options[seedLabel], germination: value }));
-    if (historyState === historyState.imported) dispatch(setHistoryStateRedux(historyState.updated));
+    if (historyState === historyStates.imported) dispatch(setHistoryStateRedux(historyStates.updated));
   };
 
   const updatePurity = (seedLabel, value) => {
@@ -81,12 +81,12 @@ const SeedTagInfo = ({
       message: 'You can also edit this information in furthur steps.',
     }));
     dispatch(setOptionRedux(seedLabel, { ...options[seedLabel], purity: value }));
-    if (historyState === historyState.imported) dispatch(setHistoryStateRedux(historyState.updated));
+    if (historyState === historyStates.imported) dispatch(setHistoryStateRedux(historyStates.updated));
   };
 
   const updateSeedsPerPound = (seedLabel, value) => {
     dispatch(setOptionRedux(seedLabel, { ...options[seedLabel], seedsPerPound: value }));
-    if (historyState === historyState.imported) dispatch(setHistoryStateRedux(historyState.updated));
+    if (historyState === historyStates.imported) dispatch(setHistoryStateRedux(historyStates.updated));
   };
 
   const seedsPerPound = (seed) => {

--- a/src/pages/Calculator/Steps/SeedingMethod/index.js
+++ b/src/pages/Calculator/Steps/SeedingMethod/index.js
@@ -14,7 +14,7 @@ import { seedingMethodsMCCC, seedingMethodsNECCC, seedingMethodsSCCC } from '../
 import Dropdown from '../../../../components/Dropdown';
 import '../steps.scss';
 import { setOptionRedux, setSeedingMethodsRedux } from '../../../../features/calculatorSlice/actions';
-import { historyState } from '../../../../features/userSlice/state';
+import { historyStates } from '../../../../features/userSlice/state';
 import { setAlertStateRedux, setHistoryStateRedux } from '../../../../features/userSlice/actions';
 
 // styles for left grid
@@ -102,7 +102,7 @@ const SeedingMethod = ({ alertState }) => {
       message: 'You can also edit this information in furthur steps.',
     }));
     setSelectedMethod(method);
-    if (historyState === historyState.imported) dispatch(setHistoryStateRedux(historyState.updated));
+    if (historyState === historyStates.imported) dispatch(setHistoryStateRedux(historyStates.updated));
   };
 
   /// ///////////////////////////////////////////////////////

--- a/src/pages/Calculator/Steps/SeedingMethod/index.js
+++ b/src/pages/Calculator/Steps/SeedingMethod/index.js
@@ -15,7 +15,7 @@ import Dropdown from '../../../../components/Dropdown';
 import '../steps.scss';
 import { setOptionRedux, setSeedingMethodsRedux } from '../../../../features/calculatorSlice/actions';
 import { historyState } from '../../../../features/userSlice/state';
-import { setAlertStateRedux, setFromUserHistoryRedux } from '../../../../features/userSlice/actions';
+import { setAlertStateRedux, setHistoryStateRedux } from '../../../../features/userSlice/actions';
 
 // styles for left grid
 const FullGrid = styled(Grid)(() => ({
@@ -67,7 +67,7 @@ const SeedingMethod = ({ alertState }) => {
   const {
     seedsSelected, sideBarSelection, options,
   } = useSelector((state) => state.calculator);
-  const { fromUserHistory } = useSelector((state) => state.user);
+  const { historyState } = useSelector((state) => state.user);
 
   // create an key/value pair for the seed and related accordion expanded state
   const [accordionState, setAccordionState] = useState(
@@ -102,7 +102,7 @@ const SeedingMethod = ({ alertState }) => {
       message: 'You can also edit this information in furthur steps.',
     }));
     setSelectedMethod(method);
-    if (fromUserHistory === historyState.imported) dispatch(setFromUserHistoryRedux(historyState.updated));
+    if (historyState === historyState.imported) dispatch(setHistoryStateRedux(historyState.updated));
   };
 
   /// ///////////////////////////////////////////////////////

--- a/src/pages/Calculator/Steps/SiteCondition/Map.js
+++ b/src/pages/Calculator/Steps/SiteCondition/Map.js
@@ -9,16 +9,19 @@ import {
   setCountyRedux, setSoilDrainageRedux, updateLatlonRedux, updateTileDrainageRedux,
   setCountyIdRedux,
 } from '../../../../features/siteConditionSlice/actions';
+import { setHistoryDialogStateRedux } from '../../../../features/userSlice/actions';
 import { getZoneData, getSSURGOData } from '../../../../features/siteConditionSlice/api';
-
+import { historyStates } from '../../../../features/userSlice/state';
 import '../steps.scss';
 
 const Map = ({
   setStep, regions,
 }) => {
   const [selectedToEditSite, setSelectedToEditSite] = useState({});
+  const [mapFeatures, setMapFeatures] = useState([]);
 
   const { council, latlon } = useSelector((state) => state.siteCondition);
+  const { historyState } = useSelector((state) => state.user);
 
   const dispatch = useDispatch();
 
@@ -29,6 +32,19 @@ const Map = ({
     } = selectedToEditSite;
 
     if (Object.keys(selectedToEditSite).length > 0) {
+      if (latitude === latlon[0] && longitude === latlon[1]) return;
+      if (historyState === historyStates.imported) {
+        dispatch(setHistoryDialogStateRedux({ open: true, type: 'update' }));
+        // reset map location to history redux
+        setMapFeatures([{
+          type: 'Feature',
+          geometry: {
+            coordinates: [latlon[1], latlon[0]],
+            type: 'Point',
+          },
+        }]);
+        return;
+      }
       // update county/zone for MCCC/NECCC
       if (council === 'MCCC') {
         const filteredCounty = regions.filter((c) => county.toLowerCase().includes(c.label.toLowerCase()));
@@ -82,6 +98,7 @@ const Map = ({
           initHeight="360px"
           initLat={latlon[0]}
           initLon={latlon[1]}
+          initFeatures={mapFeatures}
           initStartZoom={12}
           initMinZoom={4}
           initMaxZoom={18}

--- a/src/pages/Calculator/Steps/SiteCondition/form.js
+++ b/src/pages/Calculator/Steps/SiteCondition/form.js
@@ -23,6 +23,8 @@ import {
   setSoilDrainageRedux, setSoilFertilityRedux, updateTileDrainageRedux,
 } from '../../../../features/siteConditionSlice/actions';
 import '../steps.scss';
+import { historyStates } from '../../../../features/userSlice/state';
+import { setHistoryDialogStateRedux } from '../../../../features/userSlice/actions';
 
 const needTileDrainage = ['Very Poorly Drained', 'Poorly Drained', 'Somewhat Poorly Drained'];
 
@@ -82,10 +84,16 @@ const SiteConditionForm = ({
     state, soilDrainage, tileDrainage, county, plantingDate,
     soilFertility, checkNRCSStandards, acres, council,
   } = useSelector((s) => s.siteCondition);
+  // eslint-disable-next-line no-shadow
+  const { historyState } = useSelector((state) => state.user);
 
   const [soilDrainagePrev, setSoilDrainagePrev] = useState(soilDrainage);
 
   const handleState = async (e) => {
+    if (historyState === historyStates.imported) {
+      dispatch(setHistoryDialogStateRedux({ open: true, type: 'update' }));
+      return;
+    }
     const stateSelected = stateList.filter((s) => s.label === e.target.value);
     if (stateSelected.length > 0) {
       // get new regions for the selected state

--- a/src/pages/Calculator/Steps/SiteCondition/form.js
+++ b/src/pages/Calculator/Steps/SiteCondition/form.js
@@ -104,6 +104,10 @@ const SiteConditionForm = ({
   };
 
   const handleRegion = (e) => {
+    if (historyState === historyStates.imported) {
+      dispatch(setHistoryDialogStateRedux({ open: true, type: 'update' }));
+      return;
+    }
     dispatch(setCountyRedux(e.target.value));
     const countyId = regions.filter(
       (c) => c.label === e.target.value,
@@ -112,6 +116,10 @@ const SiteConditionForm = ({
   };
 
   const handleSoilDrainage = (e) => {
+    if (historyState === historyStates.imported) {
+      dispatch(setHistoryDialogStateRedux({ open: true, type: 'update' }));
+      return;
+    }
     setSoilDrainagePrev(e.target.value);
     dispatch(setSoilDrainageRedux(e.target.value));
     dispatch(updateTileDrainageRedux(false));

--- a/src/pages/Calculator/Steps/SiteCondition/index.js
+++ b/src/pages/Calculator/Steps/SiteCondition/index.js
@@ -75,29 +75,6 @@ const SiteCondition = ({
     }
   };
 
-  // const mapStateChange = async (state) => {
-  //   setMapState(state);
-  //   if (Object.keys(state).length !== 0) {
-  //     const st = states.filter(
-  //       (s) => s.label === state.properties.STATE_NAME,
-  //     );
-  //     if (st.length > 0) {
-  //       // prevent history state change and show historyDialog
-  //       console.log(historyState, historyState === historyStates.imported, st[0].label !== siteCondition.state);
-  //       if (historyState === historyStates.imported && st[0].label !== siteCondition.state) {
-  //         // dispatch(setHistoryDialogStateRedux({ open: true, type: 'update' }));
-  //         // dispatch(setStateRedux(siteCondition.state, siteCondition.stateId));
-  //         return;
-  //       }
-  //       // update regions everytime there's a state change FROM MAP
-  //       const res = await getRegions(st[0]);
-  //       setRegions(res);
-  //       // if select a new state (st[0].label different from redux state), update all related redux values
-  //       if (st[0].label !== siteCondition.state) updateStateRedux(st[0]);
-  //     }
-  //   }
-  // };
-
   // initially get states data
   useEffect(() => {
     const getStates = async () => {

--- a/src/pages/Calculator/Steps/SiteCondition/index.js
+++ b/src/pages/Calculator/Steps/SiteCondition/index.js
@@ -24,9 +24,10 @@ import '../steps.scss';
 import { historyStates } from '../../../../features/userSlice/state';
 import { setHistoryDialogStateRedux } from '../../../../features/userSlice/actions';
 
-const SiteCondition = ({ completedStep, setCompletedStep, token }) => {
+const SiteCondition = ({
+  siteConditionStep, setSiteConditionStep, completedStep, setCompletedStep, token,
+}) => {
   // Location state
-  const [step, setStep] = useState(1);
   const [mapState, setMapState] = useState({});
   const [selectedState, setSelectedState] = useState({});
   const [states, setStates] = useState([]);
@@ -163,7 +164,7 @@ const SiteCondition = ({ completedStep, setCompletedStep, token }) => {
         {siteCondition.loading === 'getLocality' ? (
           <Spinner />
         ) : (
-          step === 1 ? (
+          siteConditionStep === 1 ? (
             <>
               <RegionSelectorMap
                 selectorFunction={mapStateChange}
@@ -183,8 +184,8 @@ const SiteCondition = ({ completedStep, setCompletedStep, token }) => {
                         Would you like to manually enter your site conditions
                         or use your location to prepopulate them?
                       </Typography>
-                      <Button variant="contained" onClick={() => setStep(2)} sx={{ margin: '1rem' }}>Map</Button>
-                      <Button variant="contained" onClick={() => setStep(3)} sx={{ margin: '1rem' }}>Manually Enter</Button>
+                      <Button variant="contained" onClick={() => setSiteConditionStep(2)} sx={{ margin: '1rem' }}>Map</Button>
+                      <Button variant="contained" onClick={() => setSiteConditionStep(3)} sx={{ margin: '1rem' }}>Manually Enter</Button>
                     </Grid>
                   )
                   : (
@@ -198,15 +199,15 @@ const SiteCondition = ({ completedStep, setCompletedStep, token }) => {
               <DSTImport token={token} />
 
             </>
-          ) : step === 2 ? (
+          ) : siteConditionStep === 2 ? (
             <Map
-              setStep={setStep}
+              setStep={setSiteConditionStep}
               regions={regions}
             />
-          ) : step === 3 ? (
+          ) : siteConditionStep === 3 ? (
             <SiteConditionForm
               stateList={states}
-              setStep={setStep}
+              setStep={setSiteConditionStep}
               regions={regions}
               setRegions={setRegions}
               getRegions={getRegions}

--- a/src/pages/Calculator/Steps/SpeciesSelection/PlantList.js
+++ b/src/pages/Calculator/Steps/SpeciesSelection/PlantList.js
@@ -19,7 +19,7 @@ import {
 } from '../../../../features/calculatorSlice/actions';
 import { initialOptions } from '../../../../shared/utils/calculator';
 import { setHistoryStateRedux } from '../../../../features/userSlice/actions';
-import { historyState } from '../../../../features/userSlice/state';
+import { historyStates } from '../../../../features/userSlice/state';
 
 const CheckBoxIcon = ({ style }) => (
   <Box sx={style}>
@@ -97,8 +97,8 @@ const PlantList = ({
   };
 
   const handleClick = async (seed) => {
-    // if from user history, set historyState to historyState.updated to create a new calculation
-    if (historyState === historyState.imported) dispatch(setHistoryStateRedux(historyState.updated));
+    // if from user history, set historyState to historyStates.updated to create a new calculation
+    if (historyState === historyStates.imported) dispatch(setHistoryStateRedux(historyStates.updated));
     const { id: cropId, label: seedName } = seed;
     // if seed not in seedSelected, add it
     if (seedsSelected.filter((s) => s.label === seedName).length === 0) {

--- a/src/pages/Calculator/Steps/SpeciesSelection/PlantList.js
+++ b/src/pages/Calculator/Steps/SpeciesSelection/PlantList.js
@@ -18,7 +18,7 @@ import {
   setMixRatioOptionRedux,
 } from '../../../../features/calculatorSlice/actions';
 import { initialOptions } from '../../../../shared/utils/calculator';
-import { setFromUserHistoryRedux } from '../../../../features/userSlice/actions';
+import { setHistoryStateRedux } from '../../../../features/userSlice/actions';
 import { historyState } from '../../../../features/userSlice/state';
 
 const CheckBoxIcon = ({ style }) => (
@@ -42,7 +42,7 @@ const PlantList = ({
   const {
     acres, stateId, countyId, soilDrainage, plantingDate, soilFertility, council,
   } = useSelector((state) => state.siteCondition);
-  const { fromUserHistory } = useSelector((state) => state.user);
+  const { historyState } = useSelector((state) => state.user);
 
   const seedsSelected = useSelector((state) => state.calculator.seedsSelected);
 
@@ -97,8 +97,8 @@ const PlantList = ({
   };
 
   const handleClick = async (seed) => {
-    // if from user history, set fromUserHistory to historyState.updated to create a new calculation
-    if (fromUserHistory === historyState.imported) dispatch(setFromUserHistoryRedux(historyState.updated));
+    // if from user history, set historyState to historyState.updated to create a new calculation
+    if (historyState === historyState.imported) dispatch(setHistoryStateRedux(historyState.updated));
     const { id: cropId, label: seedName } = seed;
     // if seed not in seedSelected, add it
     if (seedsSelected.filter((s) => s.label === seedName).length === 0) {

--- a/src/pages/Calculator/Steps/SpeciesSelection/index.js
+++ b/src/pages/Calculator/Steps/SpeciesSelection/index.js
@@ -20,7 +20,8 @@ import Diversity from './diversity';
 import { removeOptionRedux, removeSeedRedux, updateDiversityRedux } from '../../../../features/calculatorSlice/actions';
 import '../steps.scss';
 import { createUserInput, createCalculator } from '../../../../shared/utils/calculator';
-import { setAlertStateRedux } from '../../../../features/userSlice/actions';
+import { setAlertStateRedux, setHistoryDialogStateRedux } from '../../../../features/userSlice/actions';
+import { historyStates } from '../../../../features/userSlice/state';
 
 const SpeciesSelection = ({ completedStep, setCompletedStep }) => {
   // useSelector for crops reducer data
@@ -32,6 +33,7 @@ const SpeciesSelection = ({ completedStep, setCompletedStep }) => {
   const {
     soilDrainage, plantingDate, acres, county, council,
   } = useSelector((state) => state.siteCondition);
+  const { historyState } = useSelector((state) => state.user);
 
   const [filteredSeeds, setFilteredSeeds] = useState([]);
   const [query, setQuery] = useState('');
@@ -70,25 +72,47 @@ const SpeciesSelection = ({ completedStep, setCompletedStep }) => {
     setAccordionState({ ...accordionState, [type]: !open });
   };
 
+  const userInput = createUserInput(soilDrainage, plantingDate, acres);
+  // use a region object array for sdk init
+  const regions = [{ label: county }];
+
   /// ///////////////////////////////////////////////////////
   //                    useEffects                         //
   /// ///////////////////////////////////////////////////////
 
   useEffect(() => {
+    if (historyState === historyStates.imported) {
+      dispatch(setHistoryDialogStateRedux({ open: true, type: 'warning' }));
+    }
+  }, []);
+
+  useEffect(() => {
     setFilteredSeeds(crops);
   }, [crops]);
 
-  const userInput = createUserInput(soilDrainage, plantingDate, acres);
-  // use a region object array for sdk init
-  const regions = [{ label: county }];
-
   // unselect crops with missing fields
   useEffect(() => {
-    // TODO: NOTE: the calculator here is only used for validating the crop
-    // , the calculator for calculation in initialized in MixRatios
+    // TODO:
+    // NOTE: the calculator here is only used for validating, the calculator for calculation is initialized in MixRatios
     try {
       // eslint-disable-next-line no-unused-vars
       const seedingRateCalculator = createCalculator(seedsSelected, council, regions, userInput);
+
+      // update diversity selected
+      let diversity = [];
+      seedsSelected.forEach((seed) => {
+        diversity.push(seed.group.label);
+      });
+      diversity = diversity.filter((group, index) => diversity.indexOf(group) === index);
+      dispatch(updateDiversityRedux(diversity));
+
+      // validate next button
+      validateForms(
+        seedsSelected.length > 1,
+        1,
+        completedStep,
+        setCompletedStep,
+      );
     } catch (err) {
       // if the crop is not valid, remove it from seedSelected
       const lastAddedSeedName = seedsSelected[seedsSelected.length - 1]?.label;
@@ -100,26 +124,6 @@ const SpeciesSelection = ({ completedStep, setCompletedStep }) => {
         message: 'Error: Invalid crop!',
       }));
     }
-  }, [seedsSelected]);
-
-  // update diversity selected
-  useEffect(() => {
-    let diversity = [];
-    seedsSelected.forEach((seed) => {
-      diversity.push(seed.group.label);
-    });
-    diversity = diversity.filter((group, index) => diversity.indexOf(group) === index);
-    dispatch(updateDiversityRedux(diversity));
-  }, [seedsSelected]);
-
-  // validate next button
-  useEffect(() => {
-    validateForms(
-      seedsSelected.length > 1,
-      1,
-      completedStep,
-      setCompletedStep,
-    );
   }, [seedsSelected]);
 
   /// ///////////////////////////////////////////////////////

--- a/src/pages/Calculator/index.js
+++ b/src/pages/Calculator/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 /// ///////////////////////////////////////////////////////
 //                      Imports                         //
 /// ///////////////////////////////////////////////////////
@@ -6,7 +7,6 @@ import React, { useEffect, useRef, useState } from 'react';
 import Grid from '@mui/material/Grid';
 import { useDispatch, useSelector } from 'react-redux';
 import { Typography, useMediaQuery } from '@mui/material';
-
 import { useTheme } from '@mui/material/styles';
 import IconButton from '@mui/material/IconButton';
 import CloseIcon from '@mui/icons-material/Close';
@@ -28,8 +28,10 @@ import SeedsSelectedList from '../../components/SeedsSelectedList';
 import { calculatorList, completedList } from '../../shared/data/dropdown';
 import StepsList from '../../components/StepsList';
 import NavBar from '../../components/NavBar';
-import { setAlertStateRedux } from '../../features/userSlice/actions';
+import { setAlertStateRedux, setHistoryStateRedux } from '../../features/userSlice/actions';
 import HistoryDialog from '../../components/HistoryDialog';
+import useUserHistory from '../../shared/hooks/useUserHistory';
+import { historyStates } from '../../features/userSlice/state';
 
 const Calculator = () => {
   // initially set calculator here
@@ -44,7 +46,7 @@ const Calculator = () => {
   const siteCondition = useSelector((state) => state.siteCondition);
   const { error: siteConditionError } = siteCondition;
   const { error: calculatorError, seedsSelected } = useSelector((state) => state.calculator);
-  const { alertState } = useSelector((state) => state.user);
+  const { alertState, historyState, selectedHistory } = useSelector((state) => state.user);
 
   const stepperRef = useRef();
 
@@ -54,6 +56,8 @@ const Calculator = () => {
   const matchesSm = useMediaQuery(theme.breakpoints.down('sm'));
 
   const { isAuthenticated, getAccessTokenSilently } = useAuth0();
+
+  const { saveHistory } = useUserHistory();
 
   /// ///////////////////////////////////////////////////////
   //                      Render                          //
@@ -161,6 +165,15 @@ const Calculator = () => {
   // close alert eveytime switch steps
   useEffect(() => {
     dispatch(setAlertStateRedux({ ...alertState, open: false }));
+    if (historyState === historyStates.new || historyState === historyStates.imported) {
+      const { label, id } = selectedHistory;
+      console.log('save history');
+      // saveHistory(token, id, label).then((res) => {
+      //   console.log('save history', res.payload.data.json);
+      //   dispatch(setHistoryStateRedux(historyStates.imported));
+      //   // set history id
+      // });
+    }
   }, [activeStep]);
 
   useEffect(() => {

--- a/src/pages/Calculator/index.js
+++ b/src/pages/Calculator/index.js
@@ -35,6 +35,7 @@ const Calculator = () => {
   // initially set calculator here
   const [calculator, setCalculator] = useState(null);
   const [activeStep, setActiveStep] = useState(0);
+  const [siteConditionStep, setSiteConditionStep] = useState(1);
   // this completedStep is to determine whether the next button is clickable on each page
   const [completedStep, setCompletedStep] = useState([...completedList]);
   const [token, setToken] = useState(null);
@@ -63,6 +64,8 @@ const Calculator = () => {
       case 'Site Conditions':
         return (
           <SiteCondition
+            siteConditionStep={siteConditionStep}
+            setSiteConditionStep={setSiteConditionStep}
             completedStep={completedStep}
             setCompletedStep={setCompletedStep}
             token={token}
@@ -310,7 +313,7 @@ const Calculator = () => {
             )}
           </Grid>
 
-          <HistoryDialog setStep={setActiveStep} />
+          <HistoryDialog setStep={setActiveStep} setSiteConditionStep={setSiteConditionStep} />
         </Grid>
 
       </Grid>

--- a/src/pages/Calculator/index.js
+++ b/src/pages/Calculator/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 /// ///////////////////////////////////////////////////////
 //                      Imports                         //
 /// ///////////////////////////////////////////////////////
@@ -24,11 +23,10 @@ import {
   CompletedPage,
 } from './Steps';
 import SeedsSelectedList from '../../components/SeedsSelectedList';
-
 import { calculatorList, completedList } from '../../shared/data/dropdown';
 import StepsList from '../../components/StepsList';
 import NavBar from '../../components/NavBar';
-import { setAlertStateRedux, setHistoryStateRedux } from '../../features/userSlice/actions';
+import { setAlertStateRedux } from '../../features/userSlice/actions';
 import HistoryDialog from '../../components/HistoryDialog';
 import useUserHistory from '../../shared/hooks/useUserHistory';
 import { historyStates } from '../../features/userSlice/state';
@@ -162,17 +160,12 @@ const Calculator = () => {
     };
   }, []);
 
-  // close alert eveytime switch steps
+  // close alert and save user history
   useEffect(() => {
     dispatch(setAlertStateRedux({ ...alertState, open: false }));
-    if (historyState === historyStates.new || historyState === historyStates.imported) {
+    if (historyState === historyStates.new || historyState === historyStates.updated) {
       const { label, id } = selectedHistory;
-      console.log('save history');
-      // saveHistory(token, id, label).then((res) => {
-      //   console.log('save history', res.payload.data.json);
-      //   dispatch(setHistoryStateRedux(historyStates.imported));
-      //   // set history id
-      // });
+      saveHistory(token, id, label);
     }
   }, [activeStep]);
 
@@ -277,6 +270,7 @@ const Calculator = () => {
             activeStep={activeStep}
             setActiveStep={setActiveStep}
             availableSteps={completedStep}
+            setSiteConditionStep={setSiteConditionStep}
           />
         </Grid>
 

--- a/src/pages/Calculator/index.js
+++ b/src/pages/Calculator/index.js
@@ -106,7 +106,7 @@ const Calculator = () => {
         );
       case 'Confirm Plan':
         return (
-          <ConfirmPlan calculator={calculator} token={token} />
+          <ConfirmPlan calculator={calculator} />
         );
       case 'Finish':
         return (
@@ -309,6 +309,7 @@ const Calculator = () => {
             )}
           </Grid>
         </Grid>
+
       </Grid>
 
       <Grid item md={0} lg={2} />

--- a/src/pages/Calculator/index.js
+++ b/src/pages/Calculator/index.js
@@ -29,6 +29,7 @@ import { calculatorList, completedList } from '../../shared/data/dropdown';
 import StepsList from '../../components/StepsList';
 import NavBar from '../../components/NavBar';
 import { setAlertStateRedux } from '../../features/userSlice/actions';
+import HistoryDialog from '../../components/HistoryDialog';
 
 const Calculator = () => {
   // initially set calculator here
@@ -308,6 +309,8 @@ const Calculator = () => {
                 : calculatorList[activeStep],
             )}
           </Grid>
+
+          <HistoryDialog />
         </Grid>
 
       </Grid>

--- a/src/pages/Calculator/index.js
+++ b/src/pages/Calculator/index.js
@@ -310,7 +310,7 @@ const Calculator = () => {
             )}
           </Grid>
 
-          <HistoryDialog />
+          <HistoryDialog setStep={setActiveStep} />
         </Grid>
 
       </Grid>

--- a/src/shared/hooks/useUserHistory.js
+++ b/src/shared/hooks/useUserHistory.js
@@ -14,6 +14,7 @@ const useUserHistory = () => {
   const siteCondition = useSelector((state) => state.siteCondition);
   // not upload crops data to user history since it's too large
   const { crops, ...calculator } = useSelector((state) => state.calculator);
+  const { historyState, selectedHistory } = useSelector((state) => state.user);
 
   /**
  * This function loads history from user history api.
@@ -54,7 +55,7 @@ const useUserHistory = () => {
           return historyList;
         }
       }
-      throw new Error('No available history record!');
+      console.error('No available history record!');
     } catch (err) {
       dispatch(setAlertStateRedux({
         open: true,
@@ -89,6 +90,7 @@ const useUserHistory = () => {
           severity: 'success',
           message: 'History updated.',
         }));
+        if (historyState !== historyStates.new) dispatch(setHistoryStateRedux(historyStates.imported));
         return res;
       // eslint-disable-next-line no-else-return
       } else {
@@ -103,6 +105,9 @@ const useUserHistory = () => {
           severity: 'success',
           message: 'History saved.',
         }));
+        // dispatch(setHistoryStateRedux(historyStates.imported));
+        dispatch(setSelectedHistoryRedux({ ...selectedHistory, id: res.payload.data.id }));
+        loadHistory(token);
         return res;
       }
     } catch (err) {

--- a/src/shared/hooks/useUserHistory.js
+++ b/src/shared/hooks/useUserHistory.js
@@ -2,7 +2,7 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { setSiteConditionRedux } from '../../features/siteConditionSlice/actions';
 import {
-  setCalculationNameRedux, setFromUserHistoryRedux, setUserHistoryListRedux, setSelectedHistoryRedux,
+  setCalculationNameRedux, setHistoryStateRedux, setUserHistoryListRedux, setSelectedHistoryRedux,
   setAlertStateRedux,
 } from '../../features/userSlice/actions';
 import { setCalculatorRedux } from '../../features/calculatorSlice/actions';
@@ -37,7 +37,7 @@ const useUserHistory = (token) => {
             dispatch(setSiteConditionRedux(data.siteCondition));
             dispatch(setCalculatorRedux(data.calculator));
             dispatch(setCalculationNameRedux(history.label));
-            dispatch(setFromUserHistoryRedux(historyState.imported));
+            dispatch(setHistoryStateRedux(historyState.imported));
             dispatch(setSelectedHistoryRedux({ label: history.label, id: history.id }));
             dispatch(setAlertStateRedux({
               open: true,

--- a/src/shared/hooks/useUserHistory.js
+++ b/src/shared/hooks/useUserHistory.js
@@ -7,7 +7,7 @@ import {
 } from '../../features/userSlice/actions';
 import { setCalculatorRedux } from '../../features/calculatorSlice/actions';
 import { getHistories, createHistory, updateHistory } from '../../features/userSlice/api';
-import { historyState } from '../../features/userSlice/state';
+import { historyStates } from '../../features/userSlice/state';
 
 const useUserHistory = (token) => {
   const dispatch = useDispatch();
@@ -37,7 +37,7 @@ const useUserHistory = (token) => {
             dispatch(setSiteConditionRedux(data.siteCondition));
             dispatch(setCalculatorRedux(data.calculator));
             dispatch(setCalculationNameRedux(history.label));
-            dispatch(setHistoryStateRedux(historyState.imported));
+            dispatch(setHistoryStateRedux(historyStates.imported));
             dispatch(setSelectedHistoryRedux({ label: history.label, id: history.id }));
             dispatch(setAlertStateRedux({
               open: true,

--- a/src/shared/hooks/useUserHistory.js
+++ b/src/shared/hooks/useUserHistory.js
@@ -2,7 +2,7 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { setSiteConditionRedux } from '../../features/siteConditionSlice/actions';
 import {
-  setCalculationNameRedux, setHistoryStateRedux, setUserHistoryListRedux, setSelectedHistoryRedux,
+  setHistoryStateRedux, setUserHistoryListRedux, setSelectedHistoryRedux,
   setAlertStateRedux,
 } from '../../features/userSlice/actions';
 import { setCalculatorRedux } from '../../features/calculatorSlice/actions';
@@ -11,7 +11,6 @@ import { historyStates } from '../../features/userSlice/state';
 
 const useUserHistory = () => {
   const dispatch = useDispatch();
-  const { calculationName } = useSelector((state) => state.user);
   const siteCondition = useSelector((state) => state.siteCondition);
   // not upload crops data to user history since it's too large
   const { crops, ...calculator } = useSelector((state) => state.calculator);
@@ -36,7 +35,6 @@ const useUserHistory = () => {
             console.log('loaded history', name, history);
             dispatch(setSiteConditionRedux(data.siteCondition));
             dispatch(setCalculatorRedux(data.calculator));
-            dispatch(setCalculationNameRedux(history.label));
             dispatch(setHistoryStateRedux(historyStates.imported));
             dispatch(setSelectedHistoryRedux({ label: history.label, id: history.id }));
             dispatch(setAlertStateRedux({
@@ -96,7 +94,7 @@ const useUserHistory = () => {
       } else {
         // if id is null, create a new history
         const params = {
-          accessToken: token, historyData: data, name: calculationName,
+          accessToken: token, historyData: data, name,
         };
         const res = await dispatch(createHistory(params));
         console.log('created history', res.payload);

--- a/src/shared/hooks/useUserHistory.js
+++ b/src/shared/hooks/useUserHistory.js
@@ -9,7 +9,7 @@ import { setCalculatorRedux } from '../../features/calculatorSlice/actions';
 import { getHistories, createHistory, updateHistory } from '../../features/userSlice/api';
 import { historyStates } from '../../features/userSlice/state';
 
-const useUserHistory = (token) => {
+const useUserHistory = () => {
   const dispatch = useDispatch();
   const { calculationName } = useSelector((state) => state.user);
   const siteCondition = useSelector((state) => state.siteCondition);
@@ -22,7 +22,7 @@ const useUserHistory = (token) => {
  * If `name` is specified, return relevant history object.
  * @param {string} name - The name of history record, default to `null`.
  */
-  const loadHistory = async (name = null) => {
+  const loadHistory = async (token = null, name = null) => {
     try {
       if (!token) throw new Error('Access token not available!');
       const res = await dispatch(getHistories({ accessToken: token }));
@@ -52,6 +52,7 @@ const useUserHistory = (token) => {
           // name is null, return a list of history name and id
           const historyList = histories.map((history) => ({ label: history.label, id: history.id }));
           dispatch(setUserHistoryListRedux(historyList));
+          console.log('historyList', historyList);
           return historyList;
         }
       }
@@ -73,15 +74,16 @@ const useUserHistory = (token) => {
  * @param {number} id - The id of history to update, default to `null`.
  * @param {string} name - The name of history to update, default to `null`.
  */
-  const saveHistory = async (id = null, name = null) => {
+  // eslint-disable-next-line consistent-return
+  const saveHistory = async (token = null, id = null, name = null) => {
     try {
       if (!token) throw new Error('Access token not available!');
       const data = { siteCondition, calculator };
       if (id !== null) {
+        // if id is not null, update history with id
         const params = {
           accessToken: token, historyData: data, name, id,
         };
-        // if id is not null, update history with id
         const res = await dispatch(updateHistory(params));
         console.log('updated history', res.payload);
         dispatch(setAlertStateRedux({
@@ -89,11 +91,13 @@ const useUserHistory = (token) => {
           severity: 'success',
           message: 'History updated.',
         }));
+        return res;
+      // eslint-disable-next-line no-else-return
       } else {
+        // if id is null, create a new history
         const params = {
           accessToken: token, historyData: data, name: calculationName,
         };
-        // if id is null, create a new history
         const res = await dispatch(createHistory(params));
         console.log('created history', res.payload);
         dispatch(setAlertStateRedux({
@@ -101,6 +105,7 @@ const useUserHistory = (token) => {
           severity: 'success',
           message: 'History saved.',
         }));
+        return res;
       }
     } catch (err) {
       dispatch(setAlertStateRedux({


### PR DESCRIPTION
- Updated historyDialog to show warnings when user try to update on first 3 steps.
- Update Site Condition page, prevent user make any changes if imported a history.
- Updated Species Selection and Mix Ratio page, show warning if imported a history.
- Added function to save history on step change, if a new calculation is created, save will trigger on every step. If a history is imported, save will only trigger if user make any changes.