### PR TITLE
Enable single species selection, fix bugs

### DIFF
--- a/src/components/SeedsSelectedList/index.js
+++ b/src/components/SeedsSelectedList/index.js
@@ -11,8 +11,11 @@ import { useDispatch, useSelector } from 'react-redux';
 import { CancelRounded } from '@mui/icons-material';
 
 import {
+  removeMixRatioOptionRedux,
   removeOptionRedux, removeSeedRedux, selectSidebarSeedRedux,
 } from '../../features/calculatorSlice/actions';
+import { historyStates } from '../../features/userSlice/state';
+import { setHistoryStateRedux } from '../../features/userSlice/actions';
 
 const ExitIcon = ({ style }) => (
   <Box sx={style}>
@@ -28,6 +31,7 @@ const SeedsSelectedList = ({ list, activeStep }) => {
   const dispatch = useDispatch();
 
   const { sideBarSelection } = useSelector((state) => state.calculator);
+  const { historyState } = useSelector((state) => state.user);
 
   const selectSpecies = (seed) => {
     dispatch(selectSidebarSeedRedux(sideBarSelection === seed ? '' : seed));
@@ -35,7 +39,9 @@ const SeedsSelectedList = ({ list, activeStep }) => {
 
   const clickItem = (label) => {
     if (activeStep === 1) {
+      if (historyState === historyStates.imported) dispatch(setHistoryStateRedux(historyStates.updated));
       dispatch(removeSeedRedux(label));
+      dispatch(removeMixRatioOptionRedux(label));
       dispatch(removeOptionRedux(label));
     } else {
       selectSpecies(label);

--- a/src/components/SeedsSelectedList/index.js
+++ b/src/components/SeedsSelectedList/index.js
@@ -13,9 +13,10 @@ import { CancelRounded } from '@mui/icons-material';
 import {
   removeMixRatioOptionRedux,
   removeOptionRedux, removeSeedRedux, selectSidebarSeedRedux,
+  setMixRatioOptionRedux,
 } from '../../features/calculatorSlice/actions';
 import { historyStates } from '../../features/userSlice/state';
-import { setHistoryStateRedux } from '../../features/userSlice/actions';
+import { setHistoryStateRedux, setMaxAvailableStepRedux } from '../../features/userSlice/actions';
 
 const ExitIcon = ({ style }) => (
   <Box sx={style}>
@@ -23,15 +24,15 @@ const ExitIcon = ({ style }) => (
   </Box>
 );
 
-const SeedsSelectedList = ({ list, activeStep }) => {
+const SeedsSelectedList = ({ activeStep }) => {
   // themes
   const theme = useTheme();
   const matchesMd = useMediaQuery(theme.breakpoints.down('md'));
 
   const dispatch = useDispatch();
 
-  const { sideBarSelection } = useSelector((state) => state.calculator);
-  const { historyState } = useSelector((state) => state.user);
+  const { sideBarSelection, seedsSelected, mixRatioOptions } = useSelector((state) => state.calculator);
+  const { historyState, maxAvailableStep } = useSelector((state) => state.user);
 
   const selectSpecies = (seed) => {
     dispatch(selectSidebarSeedRedux(sideBarSelection === seed ? '' : seed));
@@ -43,6 +44,12 @@ const SeedsSelectedList = ({ list, activeStep }) => {
       dispatch(removeSeedRedux(label));
       dispatch(removeMixRatioOptionRedux(label));
       dispatch(removeOptionRedux(label));
+      if (maxAvailableStep > 0) dispatch(setMaxAvailableStepRedux(0));
+      // reset percentOfRate in mixRatioOptions when there's any change in species selection
+      seedsSelected.forEach((s) => {
+        const seedOption = mixRatioOptions[s.label];
+        dispatch(setMixRatioOptionRedux(s.label, { ...seedOption, percentOfRate: null }));
+      });
     } else {
       selectSpecies(label);
     }
@@ -66,7 +73,7 @@ const SeedsSelectedList = ({ list, activeStep }) => {
       display="flex"
       flexDirection={matchesMd ? 'row' : 'column'}
     >
-      {[...list].reverse().map((s, i) => (
+      {[...seedsSelected].reverse().map((s, i) => (
         <Box minWidth={matchesMd ? '120px' : ''} key={i}>
 
           <Card

--- a/src/components/StepsList/index.js
+++ b/src/components/StepsList/index.js
@@ -74,7 +74,7 @@ const StepsList = ({
       return 'Please enter the necessary info below.';
     }
     if (activeStep === 1 && !availableSteps[1]) {
-      return 'Please select at least 2 plants.';
+      return 'Please select at least 1 plants.';
     }
     if (activeStep === 5 && !availableSteps[5]) {
       return 'Please make a selection.';

--- a/src/components/StepsList/index.js
+++ b/src/components/StepsList/index.js
@@ -74,7 +74,7 @@ const StepsList = ({
       return 'Please enter the necessary info below.';
     }
     if (activeStep === 1 && !availableSteps[1]) {
-      return 'Please select at least 1 plants.';
+      return 'Please select at least 1 plant.';
     }
     if (activeStep === 5 && !availableSteps[5]) {
       return 'Please make a selection.';

--- a/src/features/calculatorSlice/actions.js
+++ b/src/features/calculatorSlice/actions.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 import {
-  addSeed, removeSeed, setOption, setMixRatioOption, removeOption,
+  addSeed, removeSeed, setOption, setMixRatioOption, removeOption, removeMixRatioOption,
   updateDiversity, selectSidebarSeed, setMixSeedingRate,
   setAdjustedMixSeedingRate, importFromCSV, setBulkSeedingRate, selectUnit,
   setSeedingMethods, setCalculator,
@@ -15,6 +15,8 @@ export const setOptionRedux = (seedLabel, option) => setOption({ seedLabel, opti
 export const setMixRatioOptionRedux = (seedLabel, option) => setMixRatioOption({ seedLabel, option });
 
 export const removeOptionRedux = (seedLabel) => removeOption({ seedLabel });
+
+export const removeMixRatioOptionRedux = (seedLabel) => removeMixRatioOption({ seedLabel });
 
 export const updateDiversityRedux = (diversity) => updateDiversity({ diversity });
 

--- a/src/features/calculatorSlice/index.js
+++ b/src/features/calculatorSlice/index.js
@@ -32,6 +32,11 @@ const calculatorSlice = createSlice({
       const { [seedLabel]: removedOption, ...restOptions } = state.options;
       return { ...state, options: { ...restOptions } };
     },
+    removeMixRatioOption: (state, { payload }) => {
+      const { seedLabel } = payload;
+      const { [seedLabel]: removedOption, ...restOptions } = state.mixRatioOptions;
+      return { ...state, mixRatioOptions: { ...restOptions } };
+    },
     updateDiversity: (state, { payload }) => {
       const { diversity } = payload;
       return { ...state, diversitySelected: diversity };
@@ -91,7 +96,7 @@ const calculatorSlice = createSlice({
 });
 
 export const {
-  addSeed, removeSeed, setOption, setMixRatioOption, removeOption, updateDiversity,
+  addSeed, removeSeed, setOption, setMixRatioOption, removeOption, removeMixRatioOption, updateDiversity,
   clearSeeds, clearOptions, selectSidebarSeed, setMixSeedingRate,
   setBulkSeedingRate, setAdjustedMixSeedingRate, importFromCSV,
   selectUnit, resetCalculator, setSeedingMethods, setCalculator,

--- a/src/pages/Calculator/Steps/MixRatios/index.js
+++ b/src/pages/Calculator/Steps/MixRatios/index.js
@@ -107,7 +107,7 @@ const MixRatio = ({
   // create an key/value pair for the seed and related accordion expanded state
   const [accordionState, setAccordionState] = useState(
     seedsSelected.reduce((res, seed) => {
-      res[seed.label] = false;
+      res[seed.label] = seedsSelected.length === 1;
       return res;
     }, {}),
   );
@@ -193,12 +193,14 @@ const MixRatio = ({
 
   // expand related accordion based on sidebar click
   useEffect(() => {
-    setAccordionState(
-      seedsSelected.reduce((res, seed) => {
-        res[seed.label] = seed.label === sideBarSelection;
-        return res;
-      }, {}),
-    );
+    if (sideBarSelection !== '') {
+      setAccordionState(
+        seedsSelected.reduce((res, seed) => {
+          res[seed.label] = seed.label === sideBarSelection;
+          return res;
+        }, {}),
+      );
+    }
   }, [sideBarSelection]);
 
   /// ///////////////////////////////////////////////////////

--- a/src/pages/Calculator/Steps/MixRatios/index.js
+++ b/src/pages/Calculator/Steps/MixRatios/index.js
@@ -83,7 +83,7 @@ const MixRatio = ({
 
   const dispatch = useDispatch();
   const {
-    seedsSelected, sideBarSelection, mixRatioOptions,
+    seedsSelected, sideBarSelection, options, mixRatioOptions,
   } = useSelector((state) => state.calculator);
   const {
     council, soilDrainage, plantingDate, acres, county,
@@ -127,7 +127,10 @@ const MixRatio = ({
     const seedingRateCalculator = createCalculator(seedsSelected, council, regions, userInput);
     setCalculator(seedingRateCalculator);
     // If historyState is imported, not init options, use mixRatioOptions instead
-    if (historyState !== historyStates.imported) {
+    // or history is imported, but object is {}
+    if (historyState !== historyStates.imported || (
+      historyState === historyStates.imported && Object.keys(options).length === 0
+    )) {
       seedsSelected.forEach((seed) => {
         // if percentOfRate is not null, skip this step(this happens when add new crop for a imported history)
         if (mixRatioOptions[seed.label].percentOfRate === null) {
@@ -170,7 +173,12 @@ const MixRatio = ({
         }));
       }
       // if history is not imported, update mixRatioOptions to options
-      if (historyState !== historyStates.imported && maxAvailableStep <= 1) dispatch(setOptionRedux(seed.label, seedOption));
+      // or history is imported, but object is {}
+      if ((historyState !== historyStates.imported && maxAvailableStep <= 1) || (
+        historyState === historyStates.imported && Object.keys(options).length === 0
+      )) {
+        dispatch(setOptionRedux(seed.label, seedOption));
+      }
       // if history is updated, this will remove previously imported options redux and set it as mixRatioOptions
     });
     // calculate piechart data

--- a/src/pages/Calculator/Steps/MixRatios/index.js
+++ b/src/pages/Calculator/Steps/MixRatios/index.js
@@ -255,27 +255,31 @@ const MixRatio = ({
         )}
       </Grid>
 
-      <Grid item xs={6} sx={{ textAlign: 'justify' }}>
-        <DSTPieChart
-          chartData={piechartData.seedingRateArray}
-          label={pieChartUnits.poundsOfSeedPerAcre}
-        />
-      </Grid>
+      {seedsSelected.length > 1 && (
+        <>
+          <Grid item xs={6} sx={{ textAlign: 'justify' }}>
+            <DSTPieChart
+              chartData={piechartData.seedingRateArray}
+              label={pieChartUnits.poundsOfSeedPerAcre}
+            />
+          </Grid>
 
-      <Grid item xs={6} sx={{ textAlign: 'justify' }}>
-        {council === 'MCCC' && (
-          <DSTPieChart
-            chartData={piechartData.plantsPerSqftArray}
-            label={pieChartUnits.plantsPerSqft}
-          />
-        )}
-        {(council === 'NECCC' || council === 'SCCC') && (
-        <DSTPieChart
-          chartData={piechartData.seedsPerSqftArray}
-          label={pieChartUnits.seedsPerSqft}
-        />
-        )}
-      </Grid>
+          <Grid item xs={6} sx={{ textAlign: 'justify' }}>
+            {council === 'MCCC' && (
+            <DSTPieChart
+              chartData={piechartData.plantsPerSqftArray}
+              label={pieChartUnits.plantsPerSqft}
+            />
+            )}
+            {(council === 'NECCC' || council === 'SCCC') && (
+            <DSTPieChart
+              chartData={piechartData.seedsPerSqftArray}
+              label={pieChartUnits.seedsPerSqft}
+            />
+            )}
+          </Grid>
+        </>
+      )}
 
       {seedsSelected.map((seed, i) => (
         <Grid item xs={12} key={i}>

--- a/src/pages/Calculator/Steps/ReviewMix/index.js
+++ b/src/pages/Calculator/Steps/ReviewMix/index.js
@@ -198,27 +198,31 @@ const ReviewMix = ({ calculator }) => {
         <Typography variant="h2">Review your mix</Typography>
       </Grid>
 
-      <Grid item xs={6} sx={{ textAlign: 'justify' }}>
-        <DSTPieChart
-          chartData={piechartData.seedingRateArray}
-          label={pieChartUnits.poundsOfSeedPerAcre}
-        />
-      </Grid>
+      {seedsSelected.length > 1 && (
+        <>
+          <Grid item xs={6} sx={{ textAlign: 'justify' }}>
+            <DSTPieChart
+              chartData={piechartData.seedingRateArray}
+              label={pieChartUnits.poundsOfSeedPerAcre}
+            />
+          </Grid>
 
-      <Grid item xs={6} sx={{ textAlign: 'justify' }}>
-        {council === 'MCCC' && (
-          <DSTPieChart
-            chartData={piechartData.plantsPerSqftArray}
-            label={pieChartUnits.plantsPerSqft}
-          />
-        )}
-        {(council === 'NECCC' || council === 'SCCC') && (
-        <DSTPieChart
-          chartData={piechartData.seedsPerSqftArray}
-          label={pieChartUnits.seedsPerSqft}
-        />
-        )}
-      </Grid>
+          <Grid item xs={6} sx={{ textAlign: 'justify' }}>
+            {council === 'MCCC' && (
+            <DSTPieChart
+              chartData={piechartData.plantsPerSqftArray}
+              label={pieChartUnits.plantsPerSqft}
+            />
+            )}
+            {(council === 'NECCC' || council === 'SCCC') && (
+            <DSTPieChart
+              chartData={piechartData.seedsPerSqftArray}
+              label={pieChartUnits.seedsPerSqft}
+            />
+            )}
+          </Grid>
+        </>
+      )}
 
       {seedsSelected.map((seed, i) => (
         <Grid item xs={12} key={i}>

--- a/src/pages/Calculator/Steps/ReviewMix/index.js
+++ b/src/pages/Calculator/Steps/ReviewMix/index.js
@@ -100,7 +100,7 @@ const ReviewMix = ({ calculator }) => {
 
   const [accordionState, setAccordionState] = useState(
     seedsSelected.reduce((res, seed) => {
-      res[seed.label] = false;
+      res[seed.label] = seedsSelected.length === 1;
       return res;
     }, {}),
   );
@@ -133,12 +133,14 @@ const ReviewMix = ({ calculator }) => {
 
   // expand related accordion based on sidebar click
   useEffect(() => {
-    setAccordionState(
-      seedsSelected.reduce((res, seed) => {
-        res[seed.label] = seed.label === sideBarSelection;
-        return res;
-      }, {}),
-    );
+    if (sideBarSelection !== '') {
+      setAccordionState(
+        seedsSelected.reduce((res, seed) => {
+          res[seed.label] = seed.label === sideBarSelection;
+          return res;
+        }, {}),
+      );
+    }
   }, [sideBarSelection]);
 
   // run reviewMix on options change

--- a/src/pages/Calculator/Steps/SpeciesSelection/PlantList.js
+++ b/src/pages/Calculator/Steps/SpeciesSelection/PlantList.js
@@ -42,6 +42,7 @@ const PlantList = ({
   const {
     acres, stateId, countyId, soilDrainage, plantingDate, soilFertility, council,
   } = useSelector((state) => state.siteCondition);
+  const { mixRatioOptions } = useSelector((state) => state.calculator);
   const { historyState, maxAvailableStep } = useSelector((state) => state.user);
 
   const seedsSelected = useSelector((state) => state.calculator.seedsSelected);
@@ -127,6 +128,11 @@ const PlantList = ({
       dispatch(removeMixRatioOptionRedux(seedName));
       dispatch(removeOptionRedux(seedName));
     }
+    // reset percentOfRate in mixRatioOptions when there's any change in species selection
+    seedsSelected.forEach((s) => {
+      const seedOption = mixRatioOptions[s.label];
+      dispatch(setMixRatioOptionRedux(s.label, { ...seedOption, percentOfRate: null }));
+    });
   };
 
   return (

--- a/src/pages/Calculator/Steps/SpeciesSelection/PlantList.js
+++ b/src/pages/Calculator/Steps/SpeciesSelection/PlantList.js
@@ -14,7 +14,7 @@ import '../steps.scss';
 import { useDispatch, useSelector } from 'react-redux';
 import { CheckRounded } from '@mui/icons-material';
 import {
-  addSeedRedux, removeOptionRedux, removeSeedRedux,
+  addSeedRedux, removeMixRatioOptionRedux, removeOptionRedux, removeSeedRedux,
   setMixRatioOptionRedux,
 } from '../../../../features/calculatorSlice/actions';
 import { initialOptions } from '../../../../shared/utils/calculator';
@@ -124,6 +124,7 @@ const PlantList = ({
     } else {
     // if seed already in seedSelected, del it
       dispatch(removeSeedRedux(seedName));
+      dispatch(removeMixRatioOptionRedux(seedName));
       dispatch(removeOptionRedux(seedName));
     }
   };

--- a/src/pages/Calculator/Steps/SpeciesSelection/diversity.js
+++ b/src/pages/Calculator/Steps/SpeciesSelection/diversity.js
@@ -1,21 +1,19 @@
 /* eslint-disable no-nested-ternary */
 import * as React from 'react';
+import { useSelector } from 'react-redux';
 import Grid from '@mui/material/Grid';
 import { Typography, Box } from '@mui/material';
-
 import { seedsLabel } from '../../../../shared/data/species';
 import '../steps.scss';
 
 const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042'];
 
-const Diversity = ({ diversitySelected }) => {
-  const calculateSize = () => (diversitySelected.length === 1
-    ? 12
-    : diversitySelected.length === 2
-      ? 6
-      : diversitySelected.length >= 2 && diversitySelected.length < 4
-        ? 4
-        : 3);
+const Diversity = () => {
+  const { seedsSelected, diversitySelected } = useSelector((state) => state.calculator);
+
+  const diversityGroupLength = diversitySelected.map(
+    (diversity) => seedsSelected.filter((seed) => seed.group.label === diversity).length,
+  );
 
   return (
     <Grid container>
@@ -23,25 +21,23 @@ const Diversity = ({ diversitySelected }) => {
         Mix Diversity
       </Typography>
       <Box sx={{ width: '100%', p: '5px 0' }}>
-        <Grid
-          container
+        <Box
           sx={{
             height: '10px',
             border: '#e5e5e5 1px solid',
             borderRadius: '0.6875rem',
+            display: 'flex',
           }}
         >
           {diversitySelected.length > 0
             && diversitySelected.map((d, i) => (
-              <Grid
-                item
-                xs={calculateSize()}
-                bgcolor={COLORS[i]}
+              <Box
+                sx={{ bgcolor: `${COLORS[i]}`, flex: `${diversityGroupLength[i]}` }}
                 borderRadius="0.6875rem"
                 key={i}
               />
             ))}
-        </Grid>
+        </Box>
       </Box>
 
       {diversitySelected.length === 0 && (
@@ -49,11 +45,15 @@ const Diversity = ({ diversitySelected }) => {
           <Typography fontSize="0.75rem">Select a species</Typography>
         </Grid>
       )}
+
       {diversitySelected.length > 0
         && diversitySelected.map((d, i) => (
-          <Grid item xs={calculateSize()} key={i}>
+          <Box
+            sx={{ flex: `${diversityGroupLength[i]}` }}
+            key={i}
+          >
             <Typography fontSize="0.75rem">{seedsLabel[d]}</Typography>
-          </Grid>
+          </Box>
         ))}
     </Grid>
   );

--- a/src/pages/Calculator/Steps/SpeciesSelection/index.js
+++ b/src/pages/Calculator/Steps/SpeciesSelection/index.js
@@ -132,7 +132,7 @@ const SpeciesSelection = ({ setSiteConditionStep, completedStep, setCompletedSte
     <Grid container justifyContent="center">
       <Grid item xs={12}>
         <Typography variant="h2">
-          Click 2 or more species for your mix.
+          Select one or more species for your mix.
         </Typography>
         {historyState === historyStates.imported && (
         <Typography sx={{

--- a/src/pages/Calculator/Steps/SpeciesSelection/index.js
+++ b/src/pages/Calculator/Steps/SpeciesSelection/index.js
@@ -28,7 +28,7 @@ const SpeciesSelection = ({ setSiteConditionStep, completedStep, setCompletedSte
   const dispatch = useDispatch();
 
   const {
-    seedsSelected, diversitySelected, loading, crops,
+    seedsSelected, loading, crops,
   } = useSelector((state) => state.calculator);
   const {
     soilDrainage, plantingDate, acres, county, council,
@@ -165,7 +165,7 @@ const SpeciesSelection = ({ setSiteConditionStep, completedStep, setCompletedSte
                 Click Show details to see species options, or use the search bar to find a specific species you can pair to create a mix.
               </Typography>
             )
-            : <Diversity diversitySelected={diversitySelected} />}
+            : <Diversity />}
 
         </Box>
       </Grid>

--- a/src/pages/Calculator/Steps/SpeciesSelection/index.js
+++ b/src/pages/Calculator/Steps/SpeciesSelection/index.js
@@ -106,7 +106,7 @@ const SpeciesSelection = ({ setSiteConditionStep, completedStep, setCompletedSte
 
       // validate next button
       validateForms(
-        seedsSelected.length > 1,
+        seedsSelected.length > 0,
         1,
         completedStep,
         setCompletedStep,

--- a/src/pages/Calculator/index.js
+++ b/src/pages/Calculator/index.js
@@ -43,7 +43,7 @@ const Calculator = () => {
 
   const siteCondition = useSelector((state) => state.siteCondition);
   const { error: siteConditionError } = siteCondition;
-  const { error: calculatorError, seedsSelected } = useSelector((state) => state.calculator);
+  const { error: calculatorError } = useSelector((state) => state.calculator);
   const { alertState, historyState, selectedHistory } = useSelector((state) => state.user);
 
   const stepperRef = useRef();
@@ -305,7 +305,7 @@ const Calculator = () => {
               : {}
           }
           >
-            <SeedsSelectedList list={seedsSelected} activeStep={activeStep} />
+            <SeedsSelectedList activeStep={activeStep} />
           </Grid>
           )}
 


### PR DESCRIPTION
- Enabled single species selection, hide piecharts in Mix Ratios and Review Mix if only one species is selected.
- Updated diversity bar to be shown based on numbers of species selected.
- Fixed a bug that mixRatioOption is not updated when a crop get removed.
- Fixed a bug that the app will crash if history was made only for first 2 steps.
- Fixed a bug that percentOdRate value is not updated if make any changes in species selection.